### PR TITLE
Harden release cycle: CI, provenance, and real server smoke tests

### DIFF
--- a/.github/actions/test-hlds-image/action.yml
+++ b/.github/actions/test-hlds-image/action.yml
@@ -24,7 +24,18 @@ runs:
         touch ./mods/decay/plugin.ini
 
         mkdir -p ./config/maps
-        echo "custom-liblist" > ./config/liblist.gam
+
+        # liblist.gam tells the engine which gamedll .so to dlopen, so it's
+        # load-bearing at boot. Overwriting it with placeholder junk (as this
+        # step used to) proves the rsync-override mechanism works, but then
+        # breaks every check below that boots the live server in the same
+        # container. Pull the real one out of the image and just append a
+        # marker line, so the override is realistic AND still detectable.
+        docker run --rm --entrypoint sh "${{ inputs.image }}" \
+          -c "cat /opt/steam/hlds/${{ inputs.game }}/liblist.gam 2>/dev/null" \
+          > ./config/liblist.gam || true
+        echo '// custom-liblist-override-marker' >> ./config/liblist.gam
+
         echo "custom-mapcycle" > ./config/mapcycle.txt
         touch ./config/test.cfg
         touch ./config/maps/crazytank.bsp
@@ -104,7 +115,7 @@ runs:
         # Check that liblist.gam was overwritten (if present)
         if docker exec "${{ inputs.container-name }}" test -f "$GAME_DIR/liblist.gam"; then
           LIBLIST_CONTENT=$(docker exec "${{ inputs.container-name }}" cat "$GAME_DIR/liblist.gam")
-          if [ "$LIBLIST_CONTENT" != "custom-liblist" ]; then
+          if ! grep -q 'custom-liblist-override-marker' <<< "$LIBLIST_CONTENT"; then
             echo "liblist.gam was not overwritten!"
             exit 1
           fi

--- a/.github/actions/test-hlds-image/action.yml
+++ b/.github/actions/test-hlds-image/action.yml
@@ -1,8 +1,5 @@
 name: Test HLDS Image
-description: >
-  Boots a built hlds-docker image, validates config/mod volume mappings, and
-  smoke-tests the live GoldSrc server over its real query/RCON protocols
-  instead of only checking that setup files were copied into place.
+description: Boots a built hlds-docker image and smoke-tests the live server over its real query/RCON protocols.
 inputs:
   game:
     description: The GAME value the image was built with (e.g. valve, cstrike-legacy).
@@ -25,12 +22,8 @@ runs:
 
         mkdir -p ./config/maps
 
-        # liblist.gam tells the engine which gamedll .so to dlopen, so it's
-        # load-bearing at boot. Overwriting it with placeholder junk (as this
-        # step used to) proves the rsync-override mechanism works, but then
-        # breaks every check below that boots the live server in the same
-        # container. Pull the real one out of the image and just append a
-        # marker line, so the override is realistic AND still detectable.
+        # liblist.gam is load-bearing at boot, so append a marker instead of
+        # replacing it outright - keeps the override real but still detectable.
         docker run --rm --entrypoint sh "${{ inputs.image }}" \
           -c "cat /opt/steam/hlds/${{ inputs.game }}/liblist.gam 2>/dev/null" \
           > ./config/liblist.gam || true

--- a/.github/actions/test-hlds-image/check_a2s_info.py
+++ b/.github/actions/test-hlds-image/check_a2s_info.py
@@ -1,14 +1,5 @@
 #!/usr/bin/env python3
-"""Polls a GoldSrc server for a valid A2S_INFO response.
-
-Used two ways:
-  - By default, confirms the engine has finished booting and is answering
-    the real query protocol on its UDP port, rather than just checking that
-    setup files were copied into place before the engine was ever started.
-  - With --expect-no-response, confirms a server that was intentionally
-    given bad configuration (e.g. an unsupported GAME value) fails
-    observably instead of silently reporting itself as healthy.
-"""
+"""Polls a GoldSrc server for an A2S_INFO response; --expect-no-response inverts the check."""
 
 import argparse
 import socket

--- a/.github/actions/test-hlds-image/check_rcon.py
+++ b/.github/actions/test-hlds-image/check_rcon.py
@@ -1,11 +1,5 @@
 #!/usr/bin/env python3
-"""Performs a real RCON round-trip against a running GoldSrc server.
-
-GoldSrc RCON is UDP-based challenge/response (not the TCP protocol used by
-newer Source games). A successful exchange proves the engine has finished
-initializing its console and command systems, not just that the process
-is alive and answering basic queries.
-"""
+"""Performs a UDP challenge/response RCON round-trip against a running GoldSrc server."""
 
 import re
 import socket

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -138,9 +138,7 @@ jobs:
         id: get_image_id
         run: echo "image_id=$(docker images -q | head -n 1)" >> "$GITHUB_ENV"
 
-      # Report-only for now: severity/fixable-CVE noise on the base image hasn't
-      # been baselined against a live scan yet. Once the Security tab shows a
-      # clean run, flip exit-code to "1" to make this a blocking gate.
+      # Report-only until the Security tab has a baseline; then flip exit-code to "1".
       - name: Scan Image for Vulnerabilities 🔍
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -178,9 +178,7 @@ jobs:
         id: get_image_id
         run: echo "image_id=$(docker images -q | head -n 1)" >> "$GITHUB_ENV"
 
-      # Report-only for now: severity/fixable-CVE noise on the base image hasn't
-      # been baselined against a live scan yet. Once the Security tab shows a
-      # clean run, flip exit-code to "1" to make this a blocking gate.
+      # Report-only until the Security tab has a baseline; then flip exit-code to "1".
       - name: Scan Image for Vulnerabilities 🔍
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,12 +15,21 @@ jobs:
       contents: read
       security-events: write
     strategy:
-      # TEMPORARY: trimmed to one game while diagnosing the "Couldn't get DLL
-      # API" startup crash. Restore the full list before merging.
       matrix:
         game:
           [
             cstrike,
+            cstrike-legacy,
+            valve,
+            valve-legacy,
+            czero,
+            czero-legacy,
+            dmc,
+            gearbox,
+            ricochet,
+            dod,
+            tfc,
+            tfc-legacy,
           ]
     env:
       GAME: ${{ matrix.game }}
@@ -45,56 +54,6 @@ jobs:
       - name: Get Docker Image ID 🆔
         id: get_image_id
         run: echo "image_id=$(docker images -q | head -n 1)" >> "$GITHUB_ENV"
-
-      # TEMPORARY: diagnosing why the engine crashes with
-      # "Host_Error: Couldn't get DLL API from ..." before the server ever
-      # opens its port. Remove this step once root-caused.
-      - name: Diagnose DLL Loading Failure 🩺
-        timeout-minutes: 4
-        run: |
-          IMAGE="${{ env.image_id }}"
-
-          echo "::group::Architecture and OS"
-          timeout 15 docker run --rm --entrypoint sh "$IMAGE" -c "uname -m; cat /etc/os-release | head -5" < /dev/null || true
-          echo "::endgroup::"
-
-          echo "::group::steam user, sdk32 symlink, linux32 contents"
-          timeout 15 docker run --rm --entrypoint sh "$IMAGE" -c "id; ls -la /opt/steam/.steam 2>&1; readlink -f /opt/steam/.steam/sdk32 2>&1; ls -la /opt/steam/linux32 2>&1 | head -40" < /dev/null || true
-          echo "::endgroup::"
-
-          echo "::group::Installed i386 runtime library packages"
-          timeout 15 docker run --rm --entrypoint sh "$IMAGE" -c "dpkg -l | grep -iE 'libc6|stdc\+\+'" < /dev/null || true
-          echo "::endgroup::"
-
-          echo "::group::ldd on every .so shipped with the game (first 20)"
-          timeout 30 docker run --rm --entrypoint sh "$IMAGE" -c '
-            find /opt/steam/hlds -iname "*.so" 2>/dev/null | head -20 | while read -r f; do
-              echo "== $f ==";
-              file "$f" || true;
-              ldd "$f" 2>&1 || true;
-              echo;
-            done
-          ' < /dev/null || true
-          echo "::endgroup::"
-
-          echo "::group::hlds_run launcher script"
-          timeout 15 docker run --rm --entrypoint sh "$IMAGE" -c "cat /opt/steam/hlds/hlds_run 2>&1 | head -150" < /dev/null || true
-          echo "::endgroup::"
-
-          echo "::group::Raw launch attempt (detached, -norestart, forced cleanup)"
-          # hlds_run auto-restarts the engine forever on crash and its own
-          # SIGTERM trap is commented out in the script, so a foreground
-          # `docker run | head` here hangs indefinitely instead of exiting on
-          # crash. Run detached with -norestart (so it crashes once and
-          # stays stopped), then pull logs and force-remove regardless.
-          docker run -d --name diag-launch "$IMAGE" "-norestart +log on +maxplayers 1 +map cs_italy" || true
-          sleep 10
-          echo "--- container state ---"
-          docker inspect diag-launch --format='Status: {{.State.Status}}, ExitCode: {{.State.ExitCode}}' 2>&1 || true
-          echo "--- container logs ---"
-          docker logs diag-launch 2>&1 | head -200 || true
-          docker rm -f diag-launch >/dev/null 2>&1 || true
-          echo "::endgroup::"
 
       # Report-only for now: severity/fixable-CVE noise on the base image hasn't
       # been baselined against a live scan yet. Once the Security tab shows a

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -38,11 +38,7 @@ jobs:
       - name: Set up Docker Buildx 🛠️
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
-      # -legacy matrix entries are our own naming convention for "install the
-      # legacy steamcmd beta branch of this game" - they were never meant to
-      # be passed as a literal GAME value. hlds.txt does
-      # `app_set_config 90 mod $GAME`, so an unstripped "czero-legacy" gets
-      # passed straight through as an unrecognized mod name to steamcmd.
+      # -legacy is our own naming convention, not a literal GAME/mod value.
       - name: Set GAME environment variable 🎮
         run: |
           GAME=${{ matrix.game }}
@@ -70,9 +66,7 @@ jobs:
         id: get_image_id
         run: echo "image_id=$(docker images -q | head -n 1)" >> "$GITHUB_ENV"
 
-      # Report-only for now: severity/fixable-CVE noise on the base image hasn't
-      # been baselined against a live scan yet. Once the Security tab shows a
-      # clean run, flip exit-code to "1" to make this a blocking gate.
+      # Report-only until the Security tab has a baseline; then flip exit-code to "1".
       - name: Scan Image for Vulnerabilities 🔍
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -97,9 +91,7 @@ jobs:
           image: ${{ env.image_id }}
           container-name: hlds-${{ matrix.game }}
 
-      # Only needs to run once, not once per matrix leg: proves the entrypoint
-      # fails observably instead of reporting healthy when handed a GAME
-      # value that was never installed into the image at build time.
+      # Only needs to run once, not once per matrix leg.
       - name: Validate Invalid GAME Fails Safely 🚫
         if: matrix.game == 'valve'
         run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -81,8 +81,19 @@ jobs:
           timeout 15 docker run --rm --entrypoint sh "$IMAGE" -c "cat /opt/steam/hlds/hlds_run 2>&1 | head -150" < /dev/null || true
           echo "::endgroup::"
 
-          echo "::group::Raw entrypoint output on a real launch attempt"
-          timeout 30 docker run --rm "$IMAGE" "+log on +maxplayers 1" < /dev/null 2>&1 | head -200 || true
+          echo "::group::Raw launch attempt (detached, -norestart, forced cleanup)"
+          # hlds_run auto-restarts the engine forever on crash and its own
+          # SIGTERM trap is commented out in the script, so a foreground
+          # `docker run | head` here hangs indefinitely instead of exiting on
+          # crash. Run detached with -norestart (so it crashes once and
+          # stays stopped), then pull logs and force-remove regardless.
+          docker run -d --name diag-launch "$IMAGE" "-norestart +log on +maxplayers 1 +map cs_italy" || true
+          sleep 10
+          echo "--- container state ---"
+          docker inspect diag-launch --format='Status: {{.State.Status}}, ExitCode: {{.State.ExitCode}}' 2>&1 || true
+          echo "--- container logs ---"
+          docker logs diag-launch 2>&1 | head -200 || true
+          docker rm -f diag-launch >/dev/null 2>&1 || true
           echo "::endgroup::"
 
       # Report-only for now: severity/fixable-CVE noise on the base image hasn't

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -50,38 +50,39 @@ jobs:
       # "Host_Error: Couldn't get DLL API from ..." before the server ever
       # opens its port. Remove this step once root-caused.
       - name: Diagnose DLL Loading Failure 🩺
+        timeout-minutes: 4
         run: |
           IMAGE="${{ env.image_id }}"
 
           echo "::group::Architecture and OS"
-          docker run --rm --entrypoint sh "$IMAGE" -c "uname -m; cat /etc/os-release | head -5"
+          timeout 15 docker run --rm --entrypoint sh "$IMAGE" -c "uname -m; cat /etc/os-release | head -5" < /dev/null || true
           echo "::endgroup::"
 
           echo "::group::steam user, sdk32 symlink, linux32 contents"
-          docker run --rm --entrypoint sh "$IMAGE" -c "id; ls -la /opt/steam/.steam 2>&1; readlink -f /opt/steam/.steam/sdk32 2>&1; ls -la /opt/steam/linux32 2>&1 | head -40"
+          timeout 15 docker run --rm --entrypoint sh "$IMAGE" -c "id; ls -la /opt/steam/.steam 2>&1; readlink -f /opt/steam/.steam/sdk32 2>&1; ls -la /opt/steam/linux32 2>&1 | head -40" < /dev/null || true
           echo "::endgroup::"
 
           echo "::group::Installed i386 runtime library packages"
-          docker run --rm --entrypoint sh "$IMAGE" -c "dpkg -l | grep -iE 'libc6|stdc\+\+'"
+          timeout 15 docker run --rm --entrypoint sh "$IMAGE" -c "dpkg -l | grep -iE 'libc6|stdc\+\+'" < /dev/null || true
           echo "::endgroup::"
 
-          echo "::group::ldd on every .so shipped with the game"
-          docker run --rm --entrypoint sh "$IMAGE" -c '
-            find /opt/steam/hlds -iname "*.so" 2>/dev/null | while read -r f; do
+          echo "::group::ldd on every .so shipped with the game (first 20)"
+          timeout 30 docker run --rm --entrypoint sh "$IMAGE" -c '
+            find /opt/steam/hlds -iname "*.so" 2>/dev/null | head -20 | while read -r f; do
               echo "== $f ==";
-              file "$f";
-              ldd "$f" 2>&1;
+              file "$f" || true;
+              ldd "$f" 2>&1 || true;
               echo;
             done
-          '
+          ' < /dev/null || true
           echo "::endgroup::"
 
           echo "::group::hlds_run launcher script"
-          docker run --rm --entrypoint sh "$IMAGE" -c "cat /opt/steam/hlds/hlds_run 2>&1 | head -150"
+          timeout 15 docker run --rm --entrypoint sh "$IMAGE" -c "cat /opt/steam/hlds/hlds_run 2>&1 | head -150" < /dev/null || true
           echo "::endgroup::"
 
           echo "::group::Raw entrypoint output on a real launch attempt"
-          timeout 30 docker run --rm "$IMAGE" "+log on +maxplayers 1" 2>&1 | head -200 || true
+          timeout 30 docker run --rm "$IMAGE" "+log on +maxplayers 1" < /dev/null 2>&1 | head -200 || true
           echo "::endgroup::"
 
       # Report-only for now: severity/fixable-CVE noise on the base image hasn't

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -31,8 +31,6 @@ jobs:
             tfc,
             tfc-legacy,
           ]
-    env:
-      GAME: ${{ matrix.game }}
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -40,14 +38,31 @@ jobs:
       - name: Set up Docker Buildx 🛠️
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
+      # -legacy matrix entries are our own naming convention for "install the
+      # legacy steamcmd beta branch of this game" - they were never meant to
+      # be passed as a literal GAME value. hlds.txt does
+      # `app_set_config 90 mod $GAME`, so an unstripped "czero-legacy" gets
+      # passed straight through as an unrecognized mod name to steamcmd.
+      - name: Set GAME environment variable 🎮
+        run: |
+          GAME=${{ matrix.game }}
+          GAME=${GAME%-legacy}
+          echo "GAME=$GAME" >> "$GITHUB_ENV"
+
+      - name: Configure SteamCMD to install the legacy engine version 🚒
+        if: contains(matrix.game, 'legacy')
+        run: echo "FLAG=-beta steam_legacy" >> "$GITHUB_ENV"
+
       - name: Build Docker Image 🐳
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         env:
           GAME: ${{ env.GAME }}
+          FLAG: ${{ env.FLAG }}
         with:
           context: ./container
           build-args: |
             GAME=${{ env.GAME }}
+            FLAG=${{ env.FLAG }}
           load: true
           tags: hlds-validate:${{ matrix.game }}
 
@@ -78,7 +93,7 @@ jobs:
       - name: Test Image 🧪
         uses: ./.github/actions/test-hlds-image
         with:
-          game: ${{ matrix.game }}
+          game: ${{ env.GAME }}
           image: ${{ env.image_id }}
           container-name: hlds-${{ matrix.game }}
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,21 +15,12 @@ jobs:
       contents: read
       security-events: write
     strategy:
+      # TEMPORARY: trimmed to one game while diagnosing the "Couldn't get DLL
+      # API" startup crash. Restore the full list before merging.
       matrix:
         game:
           [
             cstrike,
-            cstrike-legacy,
-            valve,
-            valve-legacy,
-            czero,
-            czero-legacy,
-            dmc,
-            gearbox,
-            ricochet,
-            dod,
-            tfc,
-            tfc-legacy,
           ]
     env:
       GAME: ${{ matrix.game }}
@@ -54,6 +45,44 @@ jobs:
       - name: Get Docker Image ID 🆔
         id: get_image_id
         run: echo "image_id=$(docker images -q | head -n 1)" >> "$GITHUB_ENV"
+
+      # TEMPORARY: diagnosing why the engine crashes with
+      # "Host_Error: Couldn't get DLL API from ..." before the server ever
+      # opens its port. Remove this step once root-caused.
+      - name: Diagnose DLL Loading Failure 🩺
+        run: |
+          IMAGE="${{ env.image_id }}"
+
+          echo "::group::Architecture and OS"
+          docker run --rm --entrypoint sh "$IMAGE" -c "uname -m; cat /etc/os-release | head -5"
+          echo "::endgroup::"
+
+          echo "::group::steam user, sdk32 symlink, linux32 contents"
+          docker run --rm --entrypoint sh "$IMAGE" -c "id; ls -la /opt/steam/.steam 2>&1; readlink -f /opt/steam/.steam/sdk32 2>&1; ls -la /opt/steam/linux32 2>&1 | head -40"
+          echo "::endgroup::"
+
+          echo "::group::Installed i386 runtime library packages"
+          docker run --rm --entrypoint sh "$IMAGE" -c "dpkg -l | grep -iE 'libc6|stdc\+\+'"
+          echo "::endgroup::"
+
+          echo "::group::ldd on every .so shipped with the game"
+          docker run --rm --entrypoint sh "$IMAGE" -c '
+            find /opt/steam/hlds -iname "*.so" 2>/dev/null | while read -r f; do
+              echo "== $f ==";
+              file "$f";
+              ldd "$f" 2>&1;
+              echo;
+            done
+          '
+          echo "::endgroup::"
+
+          echo "::group::hlds_run launcher script"
+          docker run --rm --entrypoint sh "$IMAGE" -c "cat /opt/steam/hlds/hlds_run 2>&1 | head -150"
+          echo "::endgroup::"
+
+          echo "::group::Raw entrypoint output on a real launch attempt"
+          timeout 30 docker run --rm "$IMAGE" "+log on +maxplayers 1" 2>&1 | head -200 || true
+          echo "::endgroup::"
 
       # Report-only for now: severity/fixable-CVE noise on the base image hasn't
       # been baselined against a live scan yet. Once the Security tab shows a

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -65,16 +65,8 @@ RUN curl -v -sL media.steampowered.com/client/installer/steamcmd_linux.tar.gz | 
     file /opt/steam/linux32/steamcmd && \
     ./steamcmd.sh +runscript /opt/steam/hlds.txt
 
-# Removes the old libstdc++.so.6/libgcc_s.so.1 that SteamCMD bundles in the
-# hlds root. hlds_run puts the current directory first in LD_LIBRARY_PATH,
-# so these bundled copies shadow the lib32stdc++6 package (and its own
-# libgcc_s.so.1 dependency) installed above. That's fine for mod DLLs built
-# against an older ABI, but it breaks any mod .so rebuilt against a newer
-# libstdc++ (tfc's legacy branch needs a symbol only the system copy has) -
-# and removing just libstdc++.so.6 alone isn't enough, since the system's
-# newer libstdc++.so.6 in turn needs a newer libgcc_s.so.1 than the other
-# bundled shim still shadowing it. Removing both lets the loader fall
-# through to the system's mutually-compatible pair instead.
+# Removes SteamCMD's bundled libstdc++.so.6/libgcc_s.so.1, which shadow the
+# system libs above via LD_LIBRARY_PATH and break newer-ABI mods (tfc-legacy).
 RUN rm -f /opt/steam/hlds/libstdc++.so.6 /opt/steam/hlds/libgcc_s.so.1
 
 # Writes the steam_appid.txt file to the hlds directory with the title id for Half-Life.
@@ -94,10 +86,6 @@ COPY --chown=steam:steam mods .
 RUN chmod +x ./entrypoint.sh
 
 
-# Uses tini as the real PID 1. hlds_run (which entrypoint.sh execs into)
-# comments out its own signal trap and auto-restarts hlds_linux on crash, so
-# SIGTERM from `docker stop` would otherwise be silently ignored (PID 1 gets
-# no default disposition for untrapped signals) until Docker force-kills the
-# container. tini forwards the signal and exits when its child does, which
-# tears down the rest of the process tree cleanly.
+# tini is PID 1 so docker stop's SIGTERM is actually handled - hlds_run
+# doesn't trap it, and untrapped signals are ignored by default for PID 1.
 ENTRYPOINT ["/usr/bin/tini", "--", "./entrypoint.sh"]

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -34,7 +34,7 @@ LABEL org.opencontainers.image.version="${VERSION}"
 # Installs the necessary dependencies for the SteamCMD installer.
 RUN dpkg --add-architecture i386 && \
     apt-get update && \
-    apt-get install -y --no-install-recommends curl rsync file libc6:i386 lib32stdc++6 ca-certificates && \
+    apt-get install -y --no-install-recommends curl rsync file tini libc6:i386 lib32stdc++6 ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 # Creates a new user and group for the SteamCMD installer.
@@ -82,4 +82,10 @@ COPY --chown=steam:steam mods .
 RUN chmod +x ./entrypoint.sh
 
 
-ENTRYPOINT ["./entrypoint.sh"]
+# Uses tini as the real PID 1. hlds_run (which entrypoint.sh execs into)
+# comments out its own signal trap and auto-restarts hlds_linux on crash, so
+# SIGTERM from `docker stop` would otherwise be silently ignored (PID 1 gets
+# no default disposition for untrapped signals) until Docker force-kills the
+# container. tini forwards the signal and exits when its child does, which
+# tears down the rest of the process tree cleanly.
+ENTRYPOINT ["/usr/bin/tini", "--", "./entrypoint.sh"]

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -65,14 +65,17 @@ RUN curl -v -sL media.steampowered.com/client/installer/steamcmd_linux.tar.gz | 
     file /opt/steam/linux32/steamcmd && \
     ./steamcmd.sh +runscript /opt/steam/hlds.txt
 
-# Removes the old libstdc++.so.6 that SteamCMD bundles in the hlds root.
-# hlds_run puts the current directory first in LD_LIBRARY_PATH, so this
-# bundled copy shadows the newer lib32stdc++6 package installed above - fine
-# for mod DLLs built against an older ABI, but it breaks any mod .so that
-# was rebuilt against a newer libstdc++ (e.g. tfc's legacy branch needs a
-# symbol the bundled copy doesn't have). Removing it just falls through to
-# the system copy, which satisfies both older and newer ABI requirements.
-RUN rm -f /opt/steam/hlds/libstdc++.so.6
+# Removes the old libstdc++.so.6/libgcc_s.so.1 that SteamCMD bundles in the
+# hlds root. hlds_run puts the current directory first in LD_LIBRARY_PATH,
+# so these bundled copies shadow the lib32stdc++6 package (and its own
+# libgcc_s.so.1 dependency) installed above. That's fine for mod DLLs built
+# against an older ABI, but it breaks any mod .so rebuilt against a newer
+# libstdc++ (tfc's legacy branch needs a symbol only the system copy has) -
+# and removing just libstdc++.so.6 alone isn't enough, since the system's
+# newer libstdc++.so.6 in turn needs a newer libgcc_s.so.1 than the other
+# bundled shim still shadowing it. Removing both lets the loader fall
+# through to the system's mutually-compatible pair instead.
+RUN rm -f /opt/steam/hlds/libstdc++.so.6 /opt/steam/hlds/libgcc_s.so.1
 
 # Writes the steam_appid.txt file to the hlds directory with the title id for Half-Life.
 # Patches a known issue with the Steam client.

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -65,6 +65,15 @@ RUN curl -v -sL media.steampowered.com/client/installer/steamcmd_linux.tar.gz | 
     file /opt/steam/linux32/steamcmd && \
     ./steamcmd.sh +runscript /opt/steam/hlds.txt
 
+# Removes the old libstdc++.so.6 that SteamCMD bundles in the hlds root.
+# hlds_run puts the current directory first in LD_LIBRARY_PATH, so this
+# bundled copy shadows the newer lib32stdc++6 package installed above - fine
+# for mod DLLs built against an older ABI, but it breaks any mod .so that
+# was rebuilt against a newer libstdc++ (e.g. tfc's legacy branch needs a
+# symbol the bundled copy doesn't have). Removing it just falls through to
+# the system copy, which satisfies both older and newer ABI requirements.
+RUN rm -f /opt/steam/hlds/libstdc++.so.6
+
 # Writes the steam_appid.txt file to the hlds directory with the title id for Half-Life.
 # Patches a known issue with the Steam client.
 RUN mkdir -p $HOME/.steam \

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -62,6 +62,5 @@ echo "
 echo "\e[32mStarting Half-Life Dedicated Server...\e[0m"
 
 # Start the server with the specified game and any additional arguments.
-# Uses exec so hlds_run replaces this script as PID 1, allowing it to receive
-# SIGTERM directly from `docker stop` instead of being orphaned when the shell exits.
+# exec avoids wrapping hlds_run in an extra shell layer.
 exec ./hlds_run "-game $GAME $@"


### PR DESCRIPTION
## Summary
- SHA-pin third-party GitHub Actions and least-privilege workflow permissions
- Digest-pin the Ubuntu base image
- Trivy vulnerability scanning (report-only for now) + SARIF upload to the Security tab
- Build provenance attestation for DockerHub/GHCR pushes
- publish.yml input validation (branch guard, semver check, duplicate-release check)
- New shared composite action (`test-hlds-image`) that boots the built image and smoke-tests the real GoldSrc query/RCON protocol, not just file mappings - this caught several real, previously-invisible bugs:
  - `entrypoint.sh` never forwarded shutdown signals; `docker stop` always hit the grace period and force-killed the container
  - `validate.yml` never normalized `-legacy` matrix values, silently building wrong content for every legacy variant
  - SteamCMD bundles stale `libstdc++.so.6`/`libgcc_s.so.1` in the hlds root that shadow the system libraries, breaking `tfc-legacy` specifically
  - the test fixture itself was corrupting `liblist.gam`, which was masking all of the above behind one crash signature

## Test plan
- [x] Full 12-game matrix passes on `validate.yml` (build, boot, A2S_INFO, RCON, graceful shutdown, non-root check)
- [x] Negative-path test confirms an invalid `GAME` value fails observably
- [ ] Manual real-client join test recommended before fully trusting this in production (see PR discussion / conversation history - A2S_INFO and RCON are verified, the full connect handshake is not)