### PR TITLE
Automate release promotion with a bump dropdown

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,12 +13,11 @@ on:
           - major
         default: patch
 jobs:
-  promote:
-    name: Promote beta to main 🚀
+  version:
+    name: Compute Release Version 🔢
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -59,68 +58,9 @@ jobs:
 
           echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Promote beta to main 🚀
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          git fetch origin main beta
-
-          if git merge-base --is-ancestor origin/beta origin/main; then
-            echo "main is already up to date with beta - nothing to promote."
-            exit 0
-          fi
-
-          PREVIOUS=$(gh release view --json tagName --jq .tagName 2>/dev/null || echo "")
-          NOTES=$(gh api "repos/${{ github.repository }}/releases/generate-notes" \
-            -f tag_name="$VERSION" \
-            -f target_commitish=main \
-            -f previous_tag_name="$PREVIOUS" \
-            --jq .body)
-
-          PR_URL=$(gh pr list --base main --head beta --json url --jq '.[0].url')
-          if [ -z "$PR_URL" ]; then
-            PR_URL=$(gh pr create --base main --head beta \
-              --title "Release $VERSION: sync beta into main" \
-              --body "$NOTES")
-          fi
-          echo "Promotion PR: $PR_URL"
-
-          echo "Waiting for required checks..."
-          for _ in $(seq 1 40); do
-            VIEW=$(gh pr view "$PR_URL" --json mergeable,mergeStateStatus,statusCheckRollup)
-            MERGEABLE=$(echo "$VIEW" | jq -r '.mergeable')
-            MERGE_STATE=$(echo "$VIEW" | jq -r '.mergeStateStatus')
-
-            if [ "$MERGEABLE" = "CONFLICTING" ]; then
-              echo "::error::$PR_URL has merge conflicts and can't be promoted automatically. Resolve it manually."
-              exit 1
-            fi
-
-            FAILED=$(echo "$VIEW" | jq -r '[.statusCheckRollup[]? | select(((.conclusion // "") | ascii_downcase) as $c | $c == "failure" or $c == "cancelled" or $c == "timed_out")] | length')
-            if [ "$FAILED" -gt 0 ]; then
-              echo "::error::One or more checks failed on $PR_URL."
-              exit 1
-            fi
-
-            case "$MERGE_STATE" in
-              CLEAN|UNSTABLE|HAS_HOOKS)
-                echo "Checks passed, merging..."
-                gh pr merge "$PR_URL" --merge
-                exit 0
-                ;;
-            esac
-
-            echo "Still waiting (mergeStateStatus=$MERGE_STATE)..."
-            sleep 15
-          done
-
-          echo "::error::Timed out waiting for $PR_URL to become mergeable."
-          exit 1
-
   build:
     name: Build Docker Image 🐳
-    needs: promote
+    needs: version
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -146,13 +86,21 @@ jobs:
             tfc-legacy,
           ]
     env:
-      VERSION: ${{ needs.promote.outputs.version }}
+      VERSION: ${{ needs.version.outputs.version }}
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: main
           fetch-depth: "0"
+
+      # Tests this leg builds below run against the actual merge result, not
+      # just main on its own - this is local to the runner and isn't pushed.
+      - name: Merge beta into main (local, not pushed) 🔀
+        run: |
+          git fetch origin beta
+          git -c user.name="github-actions[bot]" -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+            merge origin/beta --no-edit
 
       - name: Set up Docker Buildx  🛠️
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
@@ -350,9 +298,32 @@ jobs:
           docker rm hlds || true
           docker system prune --all --force
 
+  merge:
+    name: Merge beta into main 🔀
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: main
+          fetch-depth: "0"
+
+      # Every build leg already proved this exact merge builds, scans, and
+      # passes the live-server smoke tests - this is the only step that
+      # actually pushes it.
+      - name: Merge and push 🔀
+        run: |
+          git fetch origin beta
+          git -c user.name="github-actions[bot]" -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+            merge origin/beta --no-edit
+          git push origin main
+
   publish:
     name: Publish GitHub Release 🚀
-    needs: [promote, build]
+    needs: [version, merge]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -365,9 +336,9 @@ jobs:
 
       - name: Create Release 🚀
         run: |
-          gh release create "${{ needs.promote.outputs.version }}" \
+          gh release create "${{ needs.version.outputs.version }}" \
             --generate-notes \
-            --title "${{ needs.promote.outputs.version }}" \
+            --title "${{ needs.version.outputs.version }}" \
             --target main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,47 +3,124 @@ concurrency: ci-${{ github.ref }}
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: "The version number to publish (e.g. v1.0.0)"
+      bump:
+        description: "Version component to bump"
         required: true
-        type: string
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
 jobs:
-  validate-inputs:
-    name: Validate Release Inputs 🔎
+  promote:
+    name: Promote beta to main 🚀
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
+      pull-requests: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: "0"
 
       - name: Validate Dispatch Branch 🌿
         run: |
-          if [ "${{ github.ref_name }}" != "main" ]; then
-            echo "::error::Releases must be published from 'main' (got '${{ github.ref_name }}'). Re-run this workflow from the main branch."
+          if [ "${{ github.ref_name }}" != "beta" ]; then
+            echo "::error::Releases must be dispatched from 'beta' (got '${{ github.ref_name }}')."
             exit 1
           fi
 
-      - name: Validate Version Format 🔢
-        run: |
-          VERSION="${{ inputs.version }}"
-          if ! echo "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "::error::Version '$VERSION' is not a valid semantic version (expected format: vX.Y.Z)."
-            exit 1
-          fi
-
-      - name: Validate Version Is Not Already Released 🔍
+      - name: Compute Next Version 🔢
+        id: version
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if gh release view "${{ inputs.version }}" >/dev/null 2>&1; then
-            echo "::error::A release for '${{ inputs.version }}' already exists. Choose a new version or delete the existing release first."
+          LATEST=$(gh release view --json tagName --jq .tagName 2>/dev/null || echo "v0.0.0")
+          VERSION="${LATEST#v}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+
+          case "${{ inputs.bump }}" in
+            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+            patch) PATCH=$((PATCH + 1)) ;;
+          esac
+
+          NEW_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
+          echo "Bumping $LATEST -> $NEW_VERSION (${{ inputs.bump }})"
+
+          if gh release view "$NEW_VERSION" >/dev/null 2>&1; then
+            echo "::error::A release for '$NEW_VERSION' already exists."
             exit 1
           fi
 
+          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Promote beta to main 🚀
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          git fetch origin main beta
+
+          if git merge-base --is-ancestor origin/beta origin/main; then
+            echo "main is already up to date with beta - nothing to promote."
+            exit 0
+          fi
+
+          PREVIOUS=$(gh release view --json tagName --jq .tagName 2>/dev/null || echo "")
+          NOTES=$(gh api "repos/${{ github.repository }}/releases/generate-notes" \
+            -f tag_name="$VERSION" \
+            -f target_commitish=main \
+            -f previous_tag_name="$PREVIOUS" \
+            --jq .body)
+
+          PR_URL=$(gh pr list --base main --head beta --json url --jq '.[0].url')
+          if [ -z "$PR_URL" ]; then
+            PR_URL=$(gh pr create --base main --head beta \
+              --title "Release $VERSION: sync beta into main" \
+              --body "$NOTES")
+          fi
+          echo "Promotion PR: $PR_URL"
+
+          echo "Waiting for required checks..."
+          for _ in $(seq 1 40); do
+            VIEW=$(gh pr view "$PR_URL" --json mergeable,mergeStateStatus,statusCheckRollup)
+            MERGEABLE=$(echo "$VIEW" | jq -r '.mergeable')
+            MERGE_STATE=$(echo "$VIEW" | jq -r '.mergeStateStatus')
+
+            if [ "$MERGEABLE" = "CONFLICTING" ]; then
+              echo "::error::$PR_URL has merge conflicts and can't be promoted automatically. Resolve it manually."
+              exit 1
+            fi
+
+            FAILED=$(echo "$VIEW" | jq -r '[.statusCheckRollup[]? | select(((.conclusion // "") | ascii_downcase) as $c | $c == "failure" or $c == "cancelled" or $c == "timed_out")] | length')
+            if [ "$FAILED" -gt 0 ]; then
+              echo "::error::One or more checks failed on $PR_URL."
+              exit 1
+            fi
+
+            case "$MERGE_STATE" in
+              CLEAN|UNSTABLE|HAS_HOOKS)
+                echo "Checks passed, merging..."
+                gh pr merge "$PR_URL" --merge
+                exit 0
+                ;;
+            esac
+
+            echo "Still waiting (mergeStateStatus=$MERGE_STATE)..."
+            sleep 15
+          done
+
+          echo "::error::Timed out waiting for $PR_URL to become mergeable."
+          exit 1
+
   build:
     name: Build Docker Image 🐳
-    needs: validate-inputs
+    needs: promote
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -68,10 +145,13 @@ jobs:
             tfc,
             tfc-legacy,
           ]
+    env:
+      VERSION: ${{ needs.promote.outputs.version }}
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          ref: main
           fetch-depth: "0"
 
       - name: Set up Docker Buildx  🛠️
@@ -132,7 +212,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/hlds
           tags: |
             type=raw,value=${{ matrix.game }}
-            type=raw,value=${{ matrix.game }}-${{ inputs.version }}
+            type=raw,value=${{ matrix.game }}-${{ env.VERSION }}
           labels: |
             org.opencontainers.image.title=Half Life Dedicated Server for ${{ env.game_title }}
             org.opencontainers.image.description=🐋 📦 Half Life Dedicated Server for ${{ env.game_title }}. Supports all the classic GoldSrc Half-Life games and mods, including the ability to add custom configurations and plugins.
@@ -142,7 +222,7 @@ jobs:
             org.opencontainers.image.url=https://github.com/jamesives/hlds-docker
             org.opencontainers.image.documentation=https://github.com/jamesives/hlds-docker
             org.opencontainers.image.source=https://github.com/jamesives/hlds-docker
-            org.opencontainers.image.version=${{ inputs.version }}
+            org.opencontainers.image.version=${{ env.VERSION }}
           annotations: |
             org.opencontainers.image.title=Half Life Dedicated Server for ${{ env.game_title }}
             org.opencontainers.image.description=🐋 📦 Half Life Dedicated Server for ${{ env.game_title }}. Supports all the classic GoldSrc Half-Life games and mods, including the ability to add custom configurations and plugins.
@@ -152,27 +232,26 @@ jobs:
             org.opencontainers.image.url=https://github.com/jamesives/hlds-docker
             org.opencontainers.image.documentation=https://github.com/jamesives/hlds-docker
             org.opencontainers.image.source=https://github.com/jamesives/hlds-docker
-            org.opencontainers.image.version=${{ inputs.version }}
+            org.opencontainers.image.version=${{ env.VERSION }}
 
       - name: Build Docker Image 🐳
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         env:
           GAME: ${{ env.GAME }}
           FLAG: ${{ env.FLAG }}
-          VERSION: ${{ inputs.version }}
-          IMAGE: jives/hlds:${{ matrix.game }}-${{ inputs.version }}
+          IMAGE: jives/hlds:${{ matrix.game }}-${{ env.VERSION }}
         with:
           context: ./container
           push: false
           load: true
           tags: |
             jives/hlds:${{ matrix.game }}
-            jives/hlds:${{ matrix.game }}-${{ inputs.version }}
+            jives/hlds:${{ matrix.game }}-${{ env.VERSION }}
           build-args: |
             GAME=${{ env.GAME }}
             FLAG=${{ env.FLAG }}
-            VERSION=${{ inputs.version }}
-            IMAGE=jives/hlds:${{ matrix.game }}-${{ inputs.version }}
+            VERSION=${{ env.VERSION }}
+            IMAGE=jives/hlds:${{ matrix.game }}-${{ env.VERSION }}
 
       - name: Get Docker Image ID 🆔
         id: get_image_id
@@ -208,21 +287,20 @@ jobs:
         env:
           GAME: ${{ env.GAME }}
           FLAG: ${{ env.FLAG }}
-          VERSION: ${{ inputs.version }}
-          IMAGE: jives/hlds:${{ matrix.game }}-${{ inputs.version }}
+          IMAGE: jives/hlds:${{ matrix.game }}-${{ env.VERSION }}
         with:
           context: ./container
           push: true
           tags: |
             jives/hlds:${{ matrix.game }}
-            jives/hlds:${{ matrix.game }}-${{ inputs.version }}
+            jives/hlds:${{ matrix.game }}-${{ env.VERSION }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
           build-args: |
             GAME=${{ env.GAME }}
             FLAG=${{ env.FLAG }}
-            VERSION=${{ inputs.version }}
-            IMAGE=jives/hlds:${{ matrix.game }}-${{ inputs.version }}
+            VERSION=${{ env.VERSION }}
+            IMAGE=jives/hlds:${{ matrix.game }}-${{ env.VERSION }}
 
       - name: Attest DockerHub Image Provenance 📜
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
@@ -242,21 +320,20 @@ jobs:
         env:
           GAME: ${{ env.GAME }}
           FLAG: ${{ env.FLAG }}
-          VERSION: ${{ inputs.version }}
-          IMAGE: ghcr.io/${{ env.repo_owner }}/hlds:${{ matrix.game }}-${{ inputs.version }}
+          IMAGE: ghcr.io/${{ env.repo_owner }}/hlds:${{ matrix.game }}-${{ env.VERSION }}
         with:
           context: ./container
           push: true
           tags: |
             ghcr.io/${{ env.repo_owner }}/hlds:${{ matrix.game }}
-            ghcr.io/${{ env.repo_owner }}/hlds:${{ matrix.game }}-${{ inputs.version }}
+            ghcr.io/${{ env.repo_owner }}/hlds:${{ matrix.game }}-${{ env.VERSION }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
           build-args: |
             GAME=${{ env.GAME }}
             FLAG=${{ env.FLAG }}
-            VERSION=${{ inputs.version }}
-            IMAGE=ghcr.io/${{ env.repo_owner }}/hlds:${{ matrix.game }}-${{ inputs.version }}
+            VERSION=${{ env.VERSION }}
+            IMAGE=ghcr.io/${{ env.repo_owner }}/hlds:${{ matrix.game }}-${{ env.VERSION }}
 
       - name: Attest GHCR Image Provenance 📜
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
@@ -275,7 +352,7 @@ jobs:
 
   publish:
     name: Publish GitHub Release 🚀
-    needs: build
+    needs: [promote, build]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -283,9 +360,14 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          ref: main
           fetch-depth: "0"
 
       - name: Create Release 🚀
-        run: gh release create "${{ inputs.version }}" --generate-notes --title "${{ inputs.version }}"
+        run: |
+          gh release create "${{ needs.promote.outputs.version }}" \
+            --generate-notes \
+            --title "${{ needs.promote.outputs.version }}" \
+            --target main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,6 +6,12 @@ on:
     branches-ignore:
       - main
       - beta
+  # beta itself is excluded above, so a beta->main promotion PR would
+  # otherwise never get these checks run against it. This targets only
+  # that case - normal feature-branch PRs already get checks via push.
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 jobs:
   build:


### PR DESCRIPTION
## Summary
- `validate.yml` now also triggers on PRs targeting `main` (it was previously excluded from both `main` and `beta`'s push trigger entirely, so a beta->main PR never got real checks run against it - confirmed empirically against beta's current HEAD).
- `publish.yml` replaces the free-text `version` input with a `bump: patch|minor|major` dropdown. A new `promote` job computes the next version from the latest release and, if beta has commits main doesn't, opens a beta->main PR with auto-generated notes and merges it once required checks pass - no more manual merging or hand-typed version strings.

## Test plan
- [ ] Full validate.yml matrix passes on this branch (doesn't exercise the new release logic directly, just confirms nothing else broke)
- [ ] Full end-to-end test of `promote` happens via a real dispatch once this is on beta (tracked separately)