### PR TITLE
fix: GHCR/DockerHub package descriptions were blank

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Docker Metadata 🏷️
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
         with:
           images: |
             jives/hlds

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -300,6 +300,8 @@ jobs:
       - name: Docker Metadata 🏷️
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
         with:
           images: |
             jives/hlds


### PR DESCRIPTION
## Summary
Package descriptions on GHCR and DockerHub were empty (e.g. https://github.com/JamesIves/hlds-docker/pkgs/container/hlds/1113584119?tag=czero-legacy) despite `docker/metadata-action` generating them correctly.

Root cause, confirmed by pulling the actual manifests from both registries: pushes are wrapped in an OCI index (to hold the build provenance attestation as a sibling manifest), and each registry's package page reads the description from whatever the tag directly points to - the index - not the per-platform manifest, which is where annotations land by default.

Fix: `DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index` on the `Docker Metadata` step in both `beta.yml` and `publish.yml`, per Docker's own docs. Verified both registries already produce an index for every push, so this is safe (no risk of the "build must produce what you're annotating" failure mode the docs warn about).

Only affects future pushes - already-published tags need a rebuild to pick up fixed descriptions.

## Test plan
- [x] Full validate.yml matrix passes (this doesn't build the annotation path directly, but confirms nothing else broke)
- [x] Real verification happens on the next beta/release push - re-check the manifest annotations land on the index this time