### PR TITLE
feat: :sparkles: add HEALTHCHECK, opt-in AUTO_UPDATE, and evergreen weekly releases

### DIFF
--- a/.github/actions/test-hlds-image/action.yml
+++ b/.github/actions/test-hlds-image/action.yml
@@ -87,15 +87,21 @@ runs:
         done
 
     # This action always boots with +rcon_password changeme, so the warning should always fire.
+    # Polled, not a single check: docker logs can lag slightly behind the container's actual
+    # stdout under load, even after the readiness file check above has already passed.
     - name: Validate rcon_password Warning Is Printed 🔑
       shell: bash
       run: |
-        if ! docker logs "${{ inputs.container-name }}" 2>&1 | grep -q "rcon_password is still set to the example default"; then
-          echo "Expected rcon_password warning was not printed for the default 'changeme' password!"
-          docker logs "${{ inputs.container-name }}" || true
-          exit 1
-        fi
-        echo "rcon_password warning correctly printed for the default password."
+        for i in $(seq 1 15); do
+          if docker logs "${{ inputs.container-name }}" 2>&1 | grep -q "rcon_password is still set to the example default"; then
+            echo "rcon_password warning correctly printed for the default password."
+            exit 0
+          fi
+          sleep 1
+        done
+        echo "Expected rcon_password warning was not printed for the default 'changeme' password!"
+        docker logs "${{ inputs.container-name }}" || true
+        exit 1
 
     - name: Validate Directory Mappings 📂
       shell: bash

--- a/.github/actions/test-hlds-image/action.yml
+++ b/.github/actions/test-hlds-image/action.yml
@@ -86,9 +86,7 @@ runs:
           sleep 2
         done
 
-    # This action always boots with +rcon_password changeme (see Run Docker
-    # Container above), so the warning should always fire - this is the
-    # trigger condition every single test run already exercises.
+    # This action always boots with +rcon_password changeme, so the warning should always fire.
     - name: Validate rcon_password Warning Is Printed 🔑
       shell: bash
       run: |

--- a/.github/actions/test-hlds-image/action.yml
+++ b/.github/actions/test-hlds-image/action.yml
@@ -149,6 +149,34 @@ runs:
       shell: bash
       run: python3 "${{ github.action_path }}/check_a2s_info.py"
 
+    - name: Validate healthcheck.sh Reports The Server As Healthy 🩺
+      shell: bash
+      run: |
+        if ! docker exec "${{ inputs.container-name }}" ./healthcheck.sh; then
+          echo "healthcheck.sh reported the running server as unhealthy!"
+          exit 1
+        fi
+        echo "healthcheck.sh reported the running server as healthy."
+
+    - name: Validate Docker Reports The Container As Healthy 🩺
+      shell: bash
+      run: |
+        echo "Waiting for the container's HEALTHCHECK to report healthy..."
+        for i in $(seq 1 20); do
+          STATUS=$(docker inspect "${{ inputs.container-name }}" --format='{{.State.Health.Status}}' 2>/dev/null || echo "unknown")
+          if [ "$STATUS" = "healthy" ]; then
+            echo "Container reported healthy after ~$((i * 3))s."
+            break
+          fi
+          if [ "$i" -eq 20 ]; then
+            echo "Container did not report healthy within 60s (last status: $STATUS)!"
+            docker inspect "${{ inputs.container-name }}" --format='{{json .State.Health}}' || true
+            exit 1
+          fi
+          echo "Attempt $i: status is '$STATUS', waiting..."
+          sleep 3
+        done
+
     - name: Validate RCON Authentication 🔑
       shell: bash
       run: python3 "${{ github.action_path }}/check_rcon.py"

--- a/.github/actions/test-hlds-image/action.yml
+++ b/.github/actions/test-hlds-image/action.yml
@@ -87,21 +87,16 @@ runs:
         done
 
     # This action always boots with +rcon_password changeme, so the warning should always fire.
-    # Polled, not a single check: docker logs can lag slightly behind the container's actual
-    # stdout under load, even after the readiness file check above has already passed.
+    # Checks the sentinel file entrypoint.sh drops, not docker logs, which proved unreliable under load.
     - name: Validate rcon_password Warning Is Printed 🔑
       shell: bash
       run: |
-        for i in $(seq 1 15); do
-          if docker logs "${{ inputs.container-name }}" 2>&1 | grep -q "rcon_password is still set to the example default"; then
-            echo "rcon_password warning correctly printed for the default password."
-            exit 0
-          fi
-          sleep 1
-        done
-        echo "Expected rcon_password warning was not printed for the default 'changeme' password!"
-        docker logs "${{ inputs.container-name }}" || true
-        exit 1
+        if ! docker exec "${{ inputs.container-name }}" test -f /tmp/.rcon-default-password-warning-shown; then
+          echo "Expected rcon_password warning was not printed for the default 'changeme' password!"
+          docker logs "${{ inputs.container-name }}" || true
+          exit 1
+        fi
+        echo "rcon_password warning correctly printed for the default password."
 
     - name: Validate Directory Mappings 📂
       shell: bash

--- a/.github/actions/test-hlds-image/action.yml
+++ b/.github/actions/test-hlds-image/action.yml
@@ -86,6 +86,19 @@ runs:
           sleep 2
         done
 
+    # This action always boots with +rcon_password changeme (see Run Docker
+    # Container above), so the warning should always fire - this is the
+    # trigger condition every single test run already exercises.
+    - name: Validate rcon_password Warning Is Printed 🔑
+      shell: bash
+      run: |
+        if ! docker logs "${{ inputs.container-name }}" 2>&1 | grep -q "rcon_password is still set to the example default"; then
+          echo "Expected rcon_password warning was not printed for the default 'changeme' password!"
+          docker logs "${{ inputs.container-name }}" || true
+          exit 1
+        fi
+        echo "rcon_password warning correctly printed for the default password."
+
     - name: Validate Directory Mappings 📂
       shell: bash
       run: |

--- a/.github/scripts/check_steam_updates.py
+++ b/.github/scripts/check_steam_updates.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Decides whether the scheduled release has anything new to publish.
+
+Compares Steam's last-updated timestamp for HLDS (app 90)'s relevant
+branches against the last GitHub release's publish time. Writes
+changed=true/false to $GITHUB_OUTPUT so the workflow can skip an entire
+rebuild-and-republish cycle when nothing changed upstream.
+"""
+
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+APP_ID = "90"
+# "public" backs the modern (non -legacy) images, "steam_legacy" backs the
+# *-legacy images pinned to the pre-25th-anniversary build.
+RELEVANT_BRANCHES = ["public", "steam_legacy"]
+
+TOKEN_RE = re.compile(r'"((?:[^"\\]|\\.)*)"|(\{)|(\})')
+
+
+def tokenize(text: str) -> list:
+    return TOKEN_RE.findall(text)
+
+
+def parse_kv(tokens: list, pos: int = 0) -> tuple:
+    """Minimal recursive-descent parser for Valve's KeyValues (VDF) text
+    format - just enough to walk the nested "key" { ... } blocks that
+    app_info_print emits, without pulling in a third-party dependency."""
+    result = {}
+    while pos < len(tokens):
+        key, open_brace, close_brace = tokens[pos]
+        pos += 1
+        if close_brace:
+            return result, pos
+
+        nxt_key, nxt_open, _ = tokens[pos]
+        if nxt_open:
+            pos += 1
+            value, pos = parse_kv(tokens, pos)
+        else:
+            value = nxt_key
+            pos += 1
+        result[key] = value
+    return result, pos
+
+
+def branch_timestamps(app_info_path: str) -> dict:
+    with open(app_info_path) as f:
+        text = f.read()
+
+    # app_info_print's output has SteamCMD log lines before the VDF block -
+    # the block itself starts at the appid key.
+    start = text.find(f'"{APP_ID}"')
+    if start == -1:
+        raise ValueError("could not find app info block in SteamCMD output")
+
+    root, _ = parse_kv(tokenize(text[start:]))
+    branches = root[APP_ID]["depots"]["branches"]
+
+    timestamps = {}
+    for name in RELEVANT_BRANCHES:
+        branch = branches.get(name)
+        if branch and "timeupdated" in branch:
+            timestamps[name] = int(branch["timeupdated"])
+    return timestamps
+
+
+def last_release_timestamp():
+    result = subprocess.run(
+        ["gh", "release", "view", "--json", "publishedAt", "--jq", ".publishedAt"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    published_at = datetime.fromisoformat(result.stdout.strip().replace("Z", "+00:00"))
+    return int(published_at.timestamp())
+
+
+def write_output(changed: bool) -> None:
+    value = "true" if changed else "false"
+    print(f"changed={value}")
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a") as f:
+            f.write(f"changed={value}\n")
+
+
+def main() -> int:
+    app_info_path = sys.argv[1] if len(sys.argv) > 1 else "/tmp/app_info.txt"
+
+    try:
+        timestamps = branch_timestamps(app_info_path)
+        if not timestamps:
+            raise ValueError("none of the expected branches were present")
+
+        for branch, ts in timestamps.items():
+            print(f"Branch '{branch}' last updated: {datetime.fromtimestamp(ts, tz=timezone.utc)}")
+
+        last_release = last_release_timestamp()
+        if last_release is None:
+            print("No prior release found; publishing.")
+            changed = True
+        else:
+            print(f"Last release published: {datetime.fromtimestamp(last_release, tz=timezone.utc)}")
+            changed = max(timestamps.values()) > last_release
+    except Exception as exc:
+        print(f"::warning::Could not determine whether Steam has updates ({exc}); publishing to be safe.")
+        changed = True
+
+    write_output(changed)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check_steam_updates.py
+++ b/.github/scripts/check_steam_updates.py
@@ -1,11 +1,5 @@
 #!/usr/bin/env python3
-"""Decides whether the scheduled release has anything new to publish.
-
-Compares Steam's last-updated timestamp for HLDS (app 90)'s relevant
-branches against the last GitHub release's publish time. Writes
-changed=true/false to $GITHUB_OUTPUT so the workflow can skip an entire
-rebuild-and-republish cycle when nothing changed upstream.
-"""
+"""Decides whether the scheduled release has anything new to publish; writes changed=true/false to $GITHUB_OUTPUT."""
 
 import os
 import re
@@ -14,8 +8,7 @@ import sys
 from datetime import datetime, timezone
 
 APP_ID = "90"
-# "public" backs the modern (non -legacy) images, "steam_legacy" backs the
-# *-legacy images pinned to the pre-25th-anniversary build.
+# "public" backs modern images, "steam_legacy" backs *-legacy images pinned to the pre-25th build.
 RELEVANT_BRANCHES = ["public", "steam_legacy"]
 
 TOKEN_RE = re.compile(r'"((?:[^"\\]|\\.)*)"|(\{)|(\})')
@@ -26,9 +19,7 @@ def tokenize(text: str) -> list:
 
 
 def parse_kv(tokens: list, pos: int = 0) -> tuple:
-    """Minimal recursive-descent parser for Valve's KeyValues (VDF) text
-    format - just enough to walk the nested "key" { ... } blocks that
-    app_info_print emits, without pulling in a third-party dependency."""
+    """Minimal recursive-descent VDF parser - just enough to walk app_info_print's nested blocks."""
     result = {}
     while pos < len(tokens):
         key, open_brace, close_brace = tokens[pos]
@@ -51,8 +42,7 @@ def branch_timestamps(app_info_path: str) -> dict:
     with open(app_info_path) as f:
         text = f.read()
 
-    # app_info_print's output has SteamCMD log lines before the VDF block -
-    # the block itself starts at the appid key.
+    # SteamCMD prints log lines before the VDF block - it starts at the appid key.
     start = text.find(f'"{APP_ID}"')
     if start == -1:
         raise ValueError("could not find app info block in SteamCMD output")

--- a/.github/scripts/check_steam_updates_test.py
+++ b/.github/scripts/check_steam_updates_test.py
@@ -1,16 +1,5 @@
 #!/usr/bin/env python3
-"""Asserts that check_steam_updates.py's parser can extract both relevant
-branches with valid timestamps from an app_info_print dump.
-
-Run with no arguments to regression-test the parser against a bundled,
-offline fixture. Run with a path to a freshly-fetched `steamcmd ...
-+app_info_print 90` dump to smoke test against real, live Steam output -
-see validate.yml, which does this once per run.
-
-Unlike check_steam_updates.py's own main(), this does NOT fail safe: a
-parse problem here should fail loudly so CI catches it, rather than
-silently falling back to "publish anyway" the way the production path does.
-"""
+"""Asserts the parser extracts valid branch timestamps; fails loudly (unlike production's fail-safe) so CI catches regressions."""
 
 import sys
 from pathlib import Path

--- a/.github/scripts/check_steam_updates_test.py
+++ b/.github/scripts/check_steam_updates_test.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Asserts that check_steam_updates.py's parser can extract both relevant
+branches with valid timestamps from an app_info_print dump.
+
+Run with no arguments to regression-test the parser against a bundled,
+offline fixture. Run with a path to a freshly-fetched `steamcmd ...
++app_info_print 90` dump to smoke test against real, live Steam output -
+see validate.yml, which does this once per run.
+
+Unlike check_steam_updates.py's own main(), this does NOT fail safe: a
+parse problem here should fail loudly so CI catches it, rather than
+silently falling back to "publish anyway" the way the production path does.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+import check_steam_updates as checker  # noqa: E402
+
+FIXTURE = Path(__file__).parent / "testdata" / "app_info_sample.txt"
+
+
+def assert_parses(app_info_path: str) -> None:
+    timestamps = checker.branch_timestamps(app_info_path)
+
+    missing = [b for b in checker.RELEVANT_BRANCHES if b not in timestamps]
+    if missing:
+        raise AssertionError(f"missing expected branch(es) {missing} - got {list(timestamps)}")
+
+    for branch, ts in timestamps.items():
+        if ts <= 0:
+            raise AssertionError(f"branch '{branch}' has a non-positive timestamp: {ts}")
+
+    print(f"OK: parsed {timestamps} from {app_info_path}")
+
+
+def main() -> int:
+    app_info_path = sys.argv[1] if len(sys.argv) > 1 else str(FIXTURE)
+    try:
+        assert_parses(app_info_path)
+    except Exception as exc:
+        print(f"FAIL: {exc}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/testdata/app_info_sample.txt
+++ b/.github/scripts/testdata/app_info_sample.txt
@@ -1,0 +1,46 @@
+Connecting anonymously to Steam Public...OK
+Waiting for client config...OK
+Waiting for user info...OK
+AppID : 90, ChangeNumber : 12345678, LastChangeNumber : 12300000, change list : ...
+"90"
+{
+	"common"
+	{
+		"name"		"Half-Life Dedicated Server"
+		"type"		"Tool"
+	}
+	"extended"
+	{
+		"developer"		"Valve"
+	}
+	"config"
+	{
+		"launch"
+		{
+		}
+	}
+	"depots"
+	{
+		"branches"
+		{
+			"public"
+			{
+				"buildid"		"11111111"
+				"timeupdated"		"1717000000"
+			}
+			"steam_legacy"
+			{
+				"buildid"		"22222222"
+				"description"		"Pre-25th Anniversary Build"
+				"timeupdated"		"1600000000"
+			}
+			"beta"
+			{
+				"buildid"		"33333333"
+				"description"		"Unrelated branch that should be ignored"
+				"timeupdated"		"1717500000"
+			}
+		}
+	}
+}
+ConVars.txt not found

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -145,6 +145,7 @@ jobs:
         with:
           image-ref: ${{ env.image_id }}
           version: v0.73.0
+          vuln-type: os
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -144,6 +144,7 @@ jobs:
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ env.image_id }}
+          version: v0.73.0
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -144,8 +144,6 @@ jobs:
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ env.image_id }}
-          version: v0.73.0
-          vuln-type: os
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -234,6 +234,7 @@ jobs:
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ env.image_id }}
+          version: v0.73.0
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -235,6 +235,7 @@ jobs:
         with:
           image-ref: ${{ env.image_id }}
           version: v0.73.0
+          vuln-type: os
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -234,8 +234,6 @@ jobs:
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ env.image_id }}
-          version: v0.73.0
-          vuln-type: os
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,11 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
+      # continue-on-error here too: a failure downloading SteamCMD itself
+      # must not stop this job before check_steam_updates.py's fail-safe
+      # gets a chance to run (see the note on the next step).
       - name: Install SteamCMD 🎮
+        continue-on-error: true
         run: |
           mkdir -p /tmp/steamcmd
           curl -sL media.steampowered.com/client/installer/steamcmd_linux.tar.gz | tar xzvf - -C /tmp/steamcmd
@@ -44,6 +48,11 @@ jobs:
       # app_info_update forces a fresh fetch from Steam instead of using a
       # local cache; app_info_print then dumps everything SteamCMD knows
       # about app 90, including each branch's last-updated timestamp.
+      # The || true matters: if this fails outright (Steam's flaky, anonymous
+      # login gets rate-limited, whatever), the next step must still run so
+      # check_steam_updates.py's own fail-safe (publish rather than silently
+      # skip) actually gets a chance to kick in, instead of the job just
+      # dying here with no output set at all.
       - name: Query Steam App Info 🔍
         run: |
           /tmp/steamcmd/steamcmd.sh \
@@ -52,7 +61,7 @@ jobs:
             +login anonymous \
             +app_info_update 1 \
             +app_info_print 90 \
-            +quit > /tmp/app_info.txt
+            +quit > /tmp/app_info.txt || true
 
       - name: Compare Against Last Release 🔍
         id: check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,11 +12,7 @@ on:
           - minor
           - major
         default: patch
-  # Keeps published images from going stale between manual releases - GoldSrc
-  # game files rarely change, so weekly is enough. This path only rebuilds
-  # main's already-released code against the current Steam depot and cuts a
-  # patch release; it never touches the beta -> main promotion below, so a
-  # work-in-progress commit on beta can't get shipped by the timer.
+  # Rebuilds main against the current Steam depot weekly - never touches the beta -> main promotion.
   schedule:
     - cron: "0 6 * * 0"
 env:
@@ -24,8 +20,7 @@ env:
 jobs:
   check-for-updates:
     name: Check Steam For Updates 🔍
-    # Manual dispatches are always an intentional decision to ship - only the
-    # weekly timer needs to ask "is there anything new to publish?" first.
+    # Manual dispatch is always intentional; only the weekly timer needs to check first.
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
     permissions:
@@ -36,23 +31,14 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      # continue-on-error here too: a failure downloading SteamCMD itself
-      # must not stop this job before check_steam_updates.py's fail-safe
-      # gets a chance to run (see the note on the next step).
+      # continue-on-error so a download failure still lets the fail-safe below run.
       - name: Install SteamCMD 🎮
         continue-on-error: true
         run: |
           mkdir -p /tmp/steamcmd
           curl -sL media.steampowered.com/client/installer/steamcmd_linux.tar.gz | tar xzvf - -C /tmp/steamcmd
 
-      # app_info_update forces a fresh fetch from Steam instead of using a
-      # local cache; app_info_print then dumps everything SteamCMD knows
-      # about app 90, including each branch's last-updated timestamp.
-      # The || true matters: if this fails outright (Steam's flaky, anonymous
-      # login gets rate-limited, whatever), the next step must still run so
-      # check_steam_updates.py's own fail-safe (publish rather than silently
-      # skip) actually gets a chance to kick in, instead of the job just
-      # dying here with no output set at all.
+      # || true: same fail-safe reasoning as the step above.
       - name: Query Steam App Info 🔍
         run: |
           /tmp/steamcmd/steamcmd.sh \
@@ -72,10 +58,7 @@ jobs:
   version:
     name: Compute Release Version 🔢
     needs: check-for-updates
-    # check-for-updates is skipped (not failed) on a manual dispatch, and a
-    # skipped need would skip this job too by default - override that. A
-    # manual dispatch always proceeds; a scheduled run only proceeds if Steam
-    # actually has something new.
+    # always() overrides default skip-propagation from check-for-updates being skipped on dispatch.
     if: |
       always() &&
       (github.event_name == 'workflow_dispatch' || needs.check-for-updates.outputs.changed == 'true')
@@ -90,9 +73,7 @@ jobs:
         with:
           fetch-depth: "0"
 
-      # Only applies to manual dispatches - a scheduled run doesn't go through
-      # the beta -> main promotion at all, so there's no "wrong branch" to
-      # guard against.
+      # Scheduled runs never touch the beta -> main promotion, so there's no branch to guard here.
       - name: Validate Dispatch Branch 🌿
         if: github.event_name == 'workflow_dispatch'
         run: |
@@ -110,8 +91,7 @@ jobs:
           VERSION="${LATEST#v}"
           IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
 
-          # workflow_dispatch supplies inputs.bump; scheduled runs have no
-          # inputs context, so default to a patch bump for those.
+          # Scheduled runs have no inputs context, so default to patch.
           BUMP="${{ inputs.bump }}"
           BUMP="${BUMP:-patch}"
 
@@ -134,8 +114,7 @@ jobs:
   prepare:
     name: Prepare Release Candidate 🔀
     needs: version
-    # Scheduled runs only refresh game files against main's current code -
-    # they never promote new commits from beta, so there's nothing to merge.
+    # Scheduled runs never promote new commits from beta, so there's nothing to merge.
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
@@ -147,12 +126,7 @@ jobs:
           ref: main
           fetch-depth: "0"
 
-      # Merges beta into main exactly once, and pushes the result to a
-      # scratch ref instead of main itself. Every downstream job builds from
-      # this one commit, so a conflict fails once and clearly here instead of
-      # noisily across all 12 matrix legs, and nothing gets pushed to a
-      # registry or released until this exact commit has been proven to
-      # build and pass its smoke tests.
+      # Pushed to a scratch ref, not main directly, so nothing ships until this commit passes tests.
       - name: Merge beta into a release candidate 🔀
         run: |
           git fetch origin beta
@@ -163,10 +137,7 @@ jobs:
   test:
     name: Test Candidate 🧪
     needs: [version, prepare]
-    # prepare is skipped (not failed) on a scheduled run, and a skipped need
-    # would skip this job too by default - override that, but still require
-    # version to have succeeded, and prepare to have succeeded on the manual
-    # path.
+    # always() overrides default skip-propagation from prepare being skipped on schedule.
     if: |
       always() && needs.version.result == 'success' &&
       (github.event_name == 'schedule' || needs.prepare.result == 'success')
@@ -192,8 +163,7 @@ jobs:
             tfc-legacy,
           ]
     steps:
-      # Scheduled runs test main's current code as-is; manual dispatches test
-      # the merged-but-not-yet-promoted candidate from the prepare job.
+      # Schedule tests main as-is; dispatch tests the not-yet-promoted candidate from prepare.
       - name: Checkout 🛎️
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -275,8 +245,7 @@ jobs:
   merge:
     name: Merge Candidate into main 🔀
     needs: test
-    # No candidate ref exists on the scheduled path (prepare didn't run), and
-    # there's nothing to promote - main's code hasn't changed.
+    # No candidate ref on the scheduled path (prepare didn't run) - nothing to promote.
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
@@ -288,9 +257,7 @@ jobs:
           ref: main
           fetch-depth: "0"
 
-      # Fast-forward only: the candidate ref is already proven to build and
-      # pass every test, so this is guaranteed conflict-free and doesn't need
-      # to redo the merge - it's just moving the main ref forward.
+      # Fast-forward only - the candidate is already proven, so this is just moving main forward.
       - name: Fast-forward main to the tested candidate 🔀
         run: |
           git fetch origin "${{ env.CANDIDATE_REF }}"
@@ -304,9 +271,7 @@ jobs:
   release:
     name: Build and Publish Image 🐳
     needs: [version, merge, test]
-    # merge is skipped (not failed) on a scheduled run - override the default
-    # skip-propagation, but still require version and test to have succeeded,
-    # and merge to have succeeded on the manual path.
+    # always() overrides default skip-propagation from merge being skipped on schedule.
     if: |
       always() && needs.version.result == 'success' && needs.test.result == 'success' &&
       (github.event_name == 'schedule' || needs.merge.result == 'success')

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,11 +12,64 @@ on:
           - minor
           - major
         default: patch
+  # Keeps published images from going stale between manual releases - GoldSrc
+  # game files rarely change, so weekly is enough. This path only rebuilds
+  # main's already-released code against the current Steam depot and cuts a
+  # patch release; it never touches the beta -> main promotion below, so a
+  # work-in-progress commit on beta can't get shipped by the timer.
+  schedule:
+    - cron: "0 6 * * 0"
 env:
   CANDIDATE_REF: release-candidate
 jobs:
+  check-for-updates:
+    name: Check Steam For Updates 🔍
+    # Manual dispatches are always an intentional decision to ship - only the
+    # weekly timer needs to ask "is there anything new to publish?" first.
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      changed: ${{ steps.check.outputs.changed }}
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Install SteamCMD 🎮
+        run: |
+          mkdir -p /tmp/steamcmd
+          curl -sL media.steampowered.com/client/installer/steamcmd_linux.tar.gz | tar xzvf - -C /tmp/steamcmd
+
+      # app_info_update forces a fresh fetch from Steam instead of using a
+      # local cache; app_info_print then dumps everything SteamCMD knows
+      # about app 90, including each branch's last-updated timestamp.
+      - name: Query Steam App Info 🔍
+        run: |
+          /tmp/steamcmd/steamcmd.sh \
+            +@ShutdownOnFailedCommand 0 \
+            +@NoPromptForPassword 1 \
+            +login anonymous \
+            +app_info_update 1 \
+            +app_info_print 90 \
+            +quit > /tmp/app_info.txt
+
+      - name: Compare Against Last Release 🔍
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 .github/scripts/check_steam_updates.py /tmp/app_info.txt
+
   version:
     name: Compute Release Version 🔢
+    needs: check-for-updates
+    # check-for-updates is skipped (not failed) on a manual dispatch, and a
+    # skipped need would skip this job too by default - override that. A
+    # manual dispatch always proceeds; a scheduled run only proceeds if Steam
+    # actually has something new.
+    if: |
+      always() &&
+      (github.event_name == 'workflow_dispatch' || needs.check-for-updates.outputs.changed == 'true')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -28,7 +81,11 @@ jobs:
         with:
           fetch-depth: "0"
 
+      # Only applies to manual dispatches - a scheduled run doesn't go through
+      # the beta -> main promotion at all, so there's no "wrong branch" to
+      # guard against.
       - name: Validate Dispatch Branch 🌿
+        if: github.event_name == 'workflow_dispatch'
         run: |
           if [ "${{ github.ref_name }}" != "beta" ]; then
             echo "::error::Releases must be dispatched from 'beta' (got '${{ github.ref_name }}')."
@@ -44,14 +101,19 @@ jobs:
           VERSION="${LATEST#v}"
           IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
 
-          case "${{ inputs.bump }}" in
+          # workflow_dispatch supplies inputs.bump; scheduled runs have no
+          # inputs context, so default to a patch bump for those.
+          BUMP="${{ inputs.bump }}"
+          BUMP="${BUMP:-patch}"
+
+          case "$BUMP" in
             major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
             minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
             patch) PATCH=$((PATCH + 1)) ;;
           esac
 
           NEW_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
-          echo "Bumping $LATEST -> $NEW_VERSION (${{ inputs.bump }})"
+          echo "Bumping $LATEST -> $NEW_VERSION ($BUMP)"
 
           if gh release view "$NEW_VERSION" >/dev/null 2>&1; then
             echo "::error::A release for '$NEW_VERSION' already exists."
@@ -63,6 +125,9 @@ jobs:
   prepare:
     name: Prepare Release Candidate 🔀
     needs: version
+    # Scheduled runs only refresh game files against main's current code -
+    # they never promote new commits from beta, so there's nothing to merge.
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -88,7 +153,14 @@ jobs:
 
   test:
     name: Test Candidate 🧪
-    needs: prepare
+    needs: [version, prepare]
+    # prepare is skipped (not failed) on a scheduled run, and a skipped need
+    # would skip this job too by default - override that, but still require
+    # version to have succeeded, and prepare to have succeeded on the manual
+    # path.
+    if: |
+      always() && needs.version.result == 'success' &&
+      (github.event_name == 'schedule' || needs.prepare.result == 'success')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -111,10 +183,12 @@ jobs:
             tfc-legacy,
           ]
     steps:
+      # Scheduled runs test main's current code as-is; manual dispatches test
+      # the merged-but-not-yet-promoted candidate from the prepare job.
       - name: Checkout 🛎️
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ env.CANDIDATE_REF }}
+          ref: ${{ github.event_name == 'schedule' && 'main' || env.CANDIDATE_REF }}
 
       - name: Set up Docker Buildx 🛠️
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
@@ -191,6 +265,9 @@ jobs:
   merge:
     name: Merge Candidate into main 🔀
     needs: test
+    # No candidate ref exists on the scheduled path (prepare didn't run), and
+    # there's nothing to promote - main's code hasn't changed.
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -216,7 +293,13 @@ jobs:
 
   release:
     name: Build and Publish Image 🐳
-    needs: [version, merge]
+    needs: [version, merge, test]
+    # merge is skipped (not failed) on a scheduled run - override the default
+    # skip-propagation, but still require version and test to have succeeded,
+    # and merge to have succeeded on the manual path.
+    if: |
+      always() && needs.version.result == 'success' && needs.test.result == 'success' &&
+      (github.event_name == 'schedule' || needs.merge.result == 'success')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -408,9 +491,16 @@ jobs:
 
       - name: Create Release 🚀
         run: |
-          gh release create "${{ needs.version.outputs.version }}" \
-            --generate-notes \
-            --title "${{ needs.version.outputs.version }}" \
-            --target main
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            gh release create "${{ needs.version.outputs.version }}" \
+              --notes "Automated weekly release to keep published game files current with Steam. No code changes." \
+              --title "${{ needs.version.outputs.version }}" \
+              --target main
+          else
+            gh release create "${{ needs.version.outputs.version }}" \
+              --generate-notes \
+              --title "${{ needs.version.outputs.version }}" \
+              --target main
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -77,6 +77,7 @@ jobs:
         with:
           image-ref: ${{ env.image_id }}
           version: v0.73.0
+          vuln-type: os
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -110,9 +110,42 @@ jobs:
           python3 .github/actions/test-hlds-image/check_a2s_info.py \
             --port 27016 --timeout 20 --expect-no-response
 
+          echo "Confirming healthcheck.sh agrees the server is unhealthy..."
+          if docker exec hlds-invalid-game ./healthcheck.sh; then
+            echo "healthcheck.sh reported healthy for a server that never started!"
+            exit 1
+          fi
+          echo "healthcheck.sh correctly reported the server as unhealthy."
+
           echo "--- Container status/logs for the invalid GAME run ---"
           docker inspect hlds-invalid-game --format='Status: {{.State.Status}}, ExitCode: {{.State.ExitCode}}'
           docker logs hlds-invalid-game || true
+
+      # Only needs to run once, not once per matrix leg - and doesn't touch
+      # Docker at all, so it can run independently of the rest of this job.
+      - name: Test Steam Update Checker Parser (Fixture) 🧪
+        if: matrix.game == 'valve'
+        run: python3 .github/scripts/check_steam_updates_test.py
+
+      # Same script, but against a live steamcmd dump instead of the bundled
+      # fixture - the fixture only proves our parser handles the VDF shape
+      # we *think* Steam returns; this proves it still matches what Steam
+      # actually returns today.
+      - name: Smoke Test Steam Update Checker (Live) 🧪
+        if: matrix.game == 'valve'
+        run: |
+          mkdir -p /tmp/steamcmd
+          curl -sL media.steampowered.com/client/installer/steamcmd_linux.tar.gz | tar xzvf - -C /tmp/steamcmd
+
+          /tmp/steamcmd/steamcmd.sh \
+            +@ShutdownOnFailedCommand 0 \
+            +@NoPromptForPassword 1 \
+            +login anonymous \
+            +app_info_update 1 \
+            +app_info_print 90 \
+            +quit > /tmp/live_app_info.txt
+
+          python3 .github/scripts/check_steam_updates_test.py /tmp/live_app_info.txt
 
       - name: Cleanup 🧹
         if: always()

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -122,9 +122,7 @@ jobs:
           docker inspect hlds-invalid-game --format='Status: {{.State.Status}}, ExitCode: {{.State.ExitCode}}'
           docker logs hlds-invalid-game || true
 
-      # Only needs to run once, not once per matrix leg. Covers the other
-      # half of the rcon_password warning: the shared test action always
-      # triggers it (changeme), this confirms a real password suppresses it.
+      # Only needs to run once. Covers the other half - a real password suppresses the warning.
       - name: Validate rcon_password Warning Is Not Printed For A Real Password 🔑
         if: matrix.game == 'valve'
         run: |
@@ -149,11 +147,7 @@ jobs:
           fi
           echo "rcon_password warning correctly suppressed for a real password."
 
-      # Only needs to run once, not once per matrix leg. Real network call to
-      # Steam (app_update validate against files already baked into the
-      # image, so no fresh download - just checksum validation), confirming
-      # AUTO_UPDATE actually runs and the server still starts normally
-      # afterward, not just that entrypoint.sh's conditional doesn't crash.
+      # Only needs to run once. Real Steam call, confirming AUTO_UPDATE runs and the server still starts.
       - name: Validate AUTO_UPDATE Runs And The Server Still Starts 🔄
         if: matrix.game == 'valve'
         run: |
@@ -183,16 +177,12 @@ jobs:
           python3 .github/actions/test-hlds-image/check_a2s_info.py --port 27019 --timeout 30
           echo "Server responded normally after an AUTO_UPDATE pass."
 
-      # Only needs to run once, not once per matrix leg - and doesn't touch
-      # Docker at all, so it can run independently of the rest of this job.
+      # Only needs to run once - doesn't touch Docker at all.
       - name: Test Steam Update Checker Parser (Fixture) 🧪
         if: matrix.game == 'valve'
         run: python3 .github/scripts/check_steam_updates_test.py
 
-      # Same script, but against a live steamcmd dump instead of the bundled
-      # fixture - the fixture only proves our parser handles the VDF shape
-      # we *think* Steam returns; this proves it still matches what Steam
-      # actually returns today.
+      # Live steamcmd dump instead of the fixture - proves it matches what Steam actually returns.
       - name: Smoke Test Steam Update Checker (Live) 🧪
         if: matrix.game == 'valve'
         run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -149,6 +149,40 @@ jobs:
           fi
           echo "rcon_password warning correctly suppressed for a real password."
 
+      # Only needs to run once, not once per matrix leg. Real network call to
+      # Steam (app_update validate against files already baked into the
+      # image, so no fresh download - just checksum validation), confirming
+      # AUTO_UPDATE actually runs and the server still starts normally
+      # afterward, not just that entrypoint.sh's conditional doesn't crash.
+      - name: Validate AUTO_UPDATE Runs And The Server Still Starts 🔄
+        if: matrix.game == 'valve'
+        run: |
+          docker run -d -ti \
+            --name hlds-auto-update \
+            -p 27019:27015/udp \
+            -e AUTO_UPDATE=true \
+            ${{ env.image_id }} \
+            "+log on +rcon_password changeme +maxplayers 12 +map bounce"
+
+          echo "Waiting for the AUTO_UPDATE SteamCMD pass to finish and the server to start..."
+          for i in $(seq 1 60); do
+            if docker logs hlds-auto-update 2>&1 | grep -q "Starting Half-Life Dedicated Server"; then
+              break
+            fi
+            echo "Attempt $i: still waiting..."
+            sleep 2
+          done
+
+          if ! docker logs hlds-auto-update 2>&1 | grep -q "AUTO_UPDATE is enabled, checking Steam for updated"; then
+            echo "AUTO_UPDATE's SteamCMD pass never ran!"
+            docker logs hlds-auto-update || true
+            exit 1
+          fi
+          echo "AUTO_UPDATE correctly ran its SteamCMD pass."
+
+          python3 .github/actions/test-hlds-image/check_a2s_info.py --port 27019 --timeout 30
+          echo "Server responded normally after an AUTO_UPDATE pass."
+
       # Only needs to run once, not once per matrix leg - and doesn't touch
       # Docker at all, so it can run independently of the rest of this job.
       - name: Test Steam Update Checker Parser (Fixture) 🧪
@@ -185,4 +219,6 @@ jobs:
           docker rm hlds-invalid-game || true
           docker stop hlds-custom-rcon || true
           docker rm hlds-custom-rcon || true
+          docker stop hlds-auto-update || true
+          docker rm hlds-auto-update || true
           docker system prune --all --force

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -76,6 +76,7 @@ jobs:
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ env.image_id }}
+          version: v0.73.0
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -132,16 +132,13 @@ jobs:
             ${{ env.image_id }} \
             "+log on +rcon_password a-real-secret-password +maxplayers 12 +map bounce"
 
-          echo "Waiting for the container entrypoint to finish its startup checks..."
-          for i in $(seq 1 15); do
-            if docker logs hlds-custom-rcon 2>&1 | grep -q "Starting Half-Life Dedicated Server"; then
-              break
-            fi
-            sleep 1
-          done
+          # The warning check runs at the very top of entrypoint.sh, well before anything
+          # slow, so a short fixed wait is plenty - and docker exec avoids docker logs,
+          # which proved unreliable under this matrix's load.
+          sleep 5
 
-          if docker logs hlds-custom-rcon 2>&1 | grep -q "rcon_password is still set to the example default"; then
-            echo "rcon_password warning printed even though a real password was set!"
+          if docker exec hlds-custom-rcon test -f /tmp/.rcon-default-password-warning-shown; then
+            echo "rcon_password warning sentinel present even though a real password was set!"
             docker logs hlds-custom-rcon || true
             exit 1
           fi
@@ -158,16 +155,18 @@ jobs:
             ${{ env.image_id }} \
             "+log on +rcon_password changeme +maxplayers 12 +map bounce"
 
-          echo "Waiting for the AUTO_UPDATE SteamCMD pass to finish and the server to start..."
+          # docker exec against a sentinel file, not docker logs - see the rcon_password
+          # warning fix above for why: docker logs proved unreliable under this matrix's load.
+          echo "Waiting for the AUTO_UPDATE SteamCMD pass to finish..."
           for i in $(seq 1 60); do
-            if docker logs hlds-auto-update 2>&1 | grep -q "Starting Half-Life Dedicated Server"; then
+            if docker exec hlds-auto-update test -f /tmp/.auto-update-ran; then
               break
             fi
             echo "Attempt $i: still waiting..."
             sleep 2
           done
 
-          if ! docker logs hlds-auto-update 2>&1 | grep -q "AUTO_UPDATE is enabled, checking Steam for updated"; then
+          if ! docker exec hlds-auto-update test -f /tmp/.auto-update-ran; then
             echo "AUTO_UPDATE's SteamCMD pass never ran!"
             docker logs hlds-auto-update || true
             exit 1

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -122,6 +122,33 @@ jobs:
           docker inspect hlds-invalid-game --format='Status: {{.State.Status}}, ExitCode: {{.State.ExitCode}}'
           docker logs hlds-invalid-game || true
 
+      # Only needs to run once, not once per matrix leg. Covers the other
+      # half of the rcon_password warning: the shared test action always
+      # triggers it (changeme), this confirms a real password suppresses it.
+      - name: Validate rcon_password Warning Is Not Printed For A Real Password 🔑
+        if: matrix.game == 'valve'
+        run: |
+          docker run -d -ti \
+            --name hlds-custom-rcon \
+            -p 27018:27015/udp \
+            ${{ env.image_id }} \
+            "+log on +rcon_password a-real-secret-password +maxplayers 12 +map bounce"
+
+          echo "Waiting for the container entrypoint to finish its startup checks..."
+          for i in $(seq 1 15); do
+            if docker logs hlds-custom-rcon 2>&1 | grep -q "Starting Half-Life Dedicated Server"; then
+              break
+            fi
+            sleep 1
+          done
+
+          if docker logs hlds-custom-rcon 2>&1 | grep -q "rcon_password is still set to the example default"; then
+            echo "rcon_password warning printed even though a real password was set!"
+            docker logs hlds-custom-rcon || true
+            exit 1
+          fi
+          echo "rcon_password warning correctly suppressed for a real password."
+
       # Only needs to run once, not once per matrix leg - and doesn't touch
       # Docker at all, so it can run independently of the rest of this job.
       - name: Test Steam Update Checker Parser (Fixture) 🧪
@@ -156,4 +183,6 @@ jobs:
           docker rm hlds-${{ matrix.game }} || true
           docker stop hlds-invalid-game || true
           docker rm hlds-invalid-game || true
+          docker stop hlds-custom-rcon || true
+          docker rm hlds-custom-rcon || true
           docker system prune --all --force

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -76,8 +76,6 @@ jobs:
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ env.image_id }}
-          version: v0.73.0
-          vuln-type: os
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -49,10 +49,11 @@ flowchart TD
     G --> H["app_set_config 90 mod $GAME"]
     H --> I["app_update 90 $FLAG validate<br>(runs 3x for reliability)"]
     I --> J[Patch steam_appid.txt = 70]
-    J --> K[Copy entrypoint.sh]
+    J --> K[Copy entrypoint.sh<br>and healthcheck.sh]
     K --> L[Copy Default Configs<br>into $GAME directory]
     L --> M[Copy Mods into<br>HLDS root]
-    M --> N[Set Entrypoint]
+    M --> HC[Set HEALTHCHECK]
+    HC --> N[Set Entrypoint]
 
     style A fill:#2d5aa0,color:#fff
     style N fill:#2d8a4e,color:#fff
@@ -60,14 +61,18 @@ flowchart TD
 
 ## Container Runtime Flow ▶️
 
-When the container starts, `entrypoint.sh` runs before the HLDS server binary. It first checks whether a `+map` argument was provided (warning the user if not, as the server won't be joinable without one). It then syncs any user-provided mods and config files from their temporary volume mount locations into the correct HLDS directories using `rsync`. Finally, it prints a branded startup banner and launches `hlds_run`.
+When the container starts, `entrypoint.sh` runs before the HLDS server binary. It first checks whether a `+map` argument was provided (warning the user if not, as the server won't be joinable without one). If `AUTO_UPDATE` is set, it re-runs SteamCMD against the persisted install directory to pick up any Valve patches before proceeding. It then syncs any user-provided mods and config files from their temporary volume mount locations into the correct HLDS directories using `rsync` - after the update, so user files still win if it restores a default. Finally, it prints a branded startup banner and launches `hlds_run`. Independently of this flow, Docker periodically runs `healthcheck.sh` against the live server - see the Health Check Flow section below.
 
 ```mermaid
 flowchart TD
     START([Container Starts]) --> CHECK{"+map" in args?}
     CHECK -->|No| WARN[Print Warning:<br>Server may not be joinable]
-    CHECK -->|Yes| MODS
-    WARN --> MODS
+    CHECK -->|Yes| UPDATE
+    WARN --> UPDATE
+
+    UPDATE{"AUTO_UPDATE<br>set?"} -->|Yes| STEAMCMD["Re-run SteamCMD<br>app_update against<br>/opt/steam/hlds"]
+    UPDATE -->|No| MODS
+    STEAMCMD --> MODS
 
     MODS{"/temp/mods<br>exists?"} -->|Yes| SYNC_MODS["rsync /temp/mods/*<br>→ /opt/steam/hlds/"]
     MODS -->|No| CFG
@@ -84,6 +89,30 @@ flowchart TD
     style START fill:#2d5aa0,color:#fff
     style LAUNCH fill:#2d8a4e,color:#fff
     style WARN fill:#c9a227,color:#000
+```
+
+## Health Check Flow 🩺
+
+Independently of `entrypoint.sh`, the Docker daemon runs `healthcheck.sh` on a fixed schedule (every 30s, 5s timeout, 60s start period, 3 retries) for as long as the container is running. The script sends a raw `A2S_INFO` query over UDP to `127.0.0.1:$PORT` (default `27015`) using bash's built-in `/dev/udp` - no extra dependencies - and succeeds only if the response starts with the expected `0xFFFFFFFF` header.
+
+```mermaid
+sequenceDiagram
+    participant Docker as Docker Daemon
+    participant HC as healthcheck.sh
+    participant HLDS as hlds_run
+
+    loop Every 30s
+        Docker->>HC: exec ./healthcheck.sh
+        HC->>HLDS: A2S_INFO query (UDP 127.0.0.1:$PORT)
+        alt Server responds
+            HLDS-->>HC: 0xFFFFFFFF + info payload
+            HC-->>Docker: exit 0 (healthy)
+        else No response within 3s
+            HC-->>Docker: exit 1 (unhealthy)
+        end
+    end
+
+    Note over Docker,HLDS: 3 consecutive failures after the<br>60s start period marks the container unhealthy
 ```
 
 ## Volume Mapping Architecture 💾
@@ -138,7 +167,7 @@ Host: ./mods/                      Container: /opt/steam/hlds/
 
 ## CI/CD Pipeline 🔄
 
-The project uses a three-branch workflow. Feature branches trigger validation only. The `beta` branch triggers beta image publishing for testing. Production releases are triggered manually via `workflow_dispatch` on `publish.yml`, which bumps the version, builds and validates all 12 game variants, pushes to both registries, and creates a GitHub Release.
+The project uses a three-branch workflow. Feature branches trigger validation only. The `beta` branch triggers beta image publishing for testing. Production releases happen two ways on `publish.yml`: manually via `workflow_dispatch`, which merges `beta` into `main`, bumps the version, builds and validates all 12 game variants, pushes to both registries, and creates a GitHub Release; or automatically on a weekly `schedule`, which skips the `beta` merge entirely and just rebuilds `main`'s already-released code against the current Steam depot, so published images don't go stale between manual releases without ever auto-promoting unreviewed code.
 
 ### Branch Strategy
 
@@ -158,7 +187,7 @@ gitGraph
 
 ### Workflow Triggers
 
-Each workflow is triggered by a specific event. Feature branch pushes run validation, beta branch pushes build and publish beta images, production releases are manually dispatched, pull requests get auto-labeled, and sponsor data is refreshed on a daily cron schedule.
+Each workflow is triggered by a specific event. Feature branch pushes run validation, beta branch pushes build and publish beta images, production releases are dispatched manually or fire weekly on a cron schedule, pull requests get auto-labeled, and sponsor data is refreshed on a daily cron schedule.
 
 ```mermaid
 flowchart TD
@@ -166,6 +195,7 @@ flowchart TD
         PUSH_FEAT["Push to feature branch"]
         PUSH_BETA["Push to beta"]
         DISPATCH["Manual Dispatch"]
+        WEEKLY["Weekly Cron"]
         PR["Pull Request"]
         CRON["Daily Cron"]
     end
@@ -181,6 +211,7 @@ flowchart TD
     PUSH_FEAT --> VAL
     PUSH_BETA --> BETA_WF
     DISPATCH --> PUB
+    WEEKLY --> PUB
     PR --> LABEL
     CRON --> SPONSOR
 
@@ -193,31 +224,41 @@ flowchart TD
 
 ### Production Publish Pipeline Detail
 
-The production publish workflow is the most complex pipeline. It is triggered manually via `workflow_dispatch` with a required `version` input, and runs a build matrix for all 12 game variants. For each variant, it strips the `-legacy` suffix from the game name (if present) and sets the appropriate SteamCMD beta flag. After building, it runs the container with test configurations to validate that volume mappings and game data are correct before pushing to both Docker Hub and GitHub Container Registry. Once all builds pass, the publish job creates the GitHub Release and version tag from the supplied `version` input.
+The production publish workflow can start two ways: manually via `workflow_dispatch` with a `bump` choice (patch/minor/major), or automatically every week via `schedule`. The scheduled path runs one extra gate first: it queries Steam's `app_info` for HLDS's `public` and `steam_legacy` branch update timestamps and compares them against the last release's publish time, stopping immediately (no version bump, no build, no new tags) if nothing changed - GoldSrc games are rarely patched, so most weekly ticks are expected to stop here rather than publish 12 near-duplicate tags for nothing. A manual dispatch always skips this check and proceeds, since a human explicitly asking for a release is reason enough. Both paths that do proceed compute the next version and run the same 12-variant test matrix (build, Trivy scan, and the shared smoke test action) before anything is pushed. The manual path first merges `beta` into a scratch `release-candidate` ref and, once tests pass, fast-forwards `main` to it - promoting new code. The scheduled path skips that merge entirely: it tests and rebuilds `main`'s already-released code as-is, so a fresh SteamCMD download against the current Steam depot is the only thing that changes. Once tests pass, both paths build and push all 12 variants to Docker Hub and GHCR, attest provenance, and create a GitHub Release.
 
 ```mermaid
 flowchart TD
-    A[Manual Dispatch<br>with version input] --> D[Build Job - Matrix x12]
+    A[Manual Dispatch<br>bump: patch/minor/major] --> V[Compute Next Version]
+    B[Weekly Schedule] --> CHECK{Steam depot changed<br>since last release?}
+    CHECK -->|No| STOP[Stop -<br>nothing to publish]
+    CHECK -->|Yes| V
 
-    D --> E[Login to Docker Hub + GHCR]
-    E --> F[Set GAME env var<br>Strip -legacy suffix]
-    F --> G{Legacy variant?}
-    G -->|Yes| H["Set FLAG=-beta steam_legacy"]
-    G -->|No| I[FLAG empty]
-    H --> J
-    I --> J[Build Image Locally]
-    J --> K[Run Container with Test Config]
-    K --> L{Validate Directory<br>Mappings}
-    L -->|Pass| M[Push to Docker Hub<br>jives/hlds:game<br>jives/hlds:game-version]
-    L -->|Fail| X[❌ Build Fails]
-    M --> N[Push to GHCR<br>ghcr.io/jamesives/hlds:game<br>ghcr.io/jamesives/hlds:game-version]
+    V --> BRANCH{Triggered by?}
+    BRANCH -->|Manual| PREP["Merge beta into<br>release-candidate ref"]
+    BRANCH -->|Schedule| SKIP1["Skip merge -<br>main unchanged"]
 
-    N --> O[Publish Job]
-    O --> Q[Create GitHub Release<br>from version input]
+    PREP --> TEST
+    SKIP1 --> TEST
+
+    TEST["Test Job - Matrix x12<br>Build · Trivy Scan · Smoke Test"]
+
+    TEST --> BRANCH2{Triggered by?}
+    BRANCH2 -->|Manual| MERGE["Fast-forward main<br>to tested candidate"]
+    BRANCH2 -->|Schedule| SKIP2["Skip merge -<br>main already correct"]
+
+    MERGE --> RELEASE
+    SKIP2 --> RELEASE
+
+    RELEASE["Release Job - Matrix x12<br>Fresh SteamCMD download<br>Push to Docker Hub + GHCR<br>Attest Provenance"]
+
+    RELEASE --> PUBLISH[Publish Job<br>Create GitHub Release + Tag]
 
     style A fill:#2d5aa0,color:#fff
-    style Q fill:#2d8a4e,color:#fff
-    style X fill:#cc3333,color:#fff
+    style B fill:#2d5aa0,color:#fff
+    style PUBLISH fill:#2d8a4e,color:#fff
+    style SKIP1 fill:#c9a227,color:#000
+    style SKIP2 fill:#c9a227,color:#000
+    style STOP fill:#c9a227,color:#000
 ```
 
 ## Validation Test Matrix ✅

--- a/README.md
+++ b/README.md
@@ -57,6 +57,43 @@ Once the command finishes, you can connect to your server via the public IP addr
 
 If you'd prefer to configure your server using [Docker Compose](https://docs.docker.com/compose/), you can pull down the project repository to your system and run `docker compose up` from the root. Make any modifications you need, such as changing the game image and server startup commands in [docker-compose.yml](docker-compose.yml) before running `docker compose up`.
 
+### Health Checks 🩺
+
+The image ships with a Docker [`HEALTHCHECK`](https://docs.docker.com/reference/dockerfile/#healthcheck) that polls the running server every 30 seconds with a real `A2S_INFO` query - the same query Steam's own server browser uses - so Docker (and anything watching container health, like `docker ps`, Compose, Swarm, or Kubernetes) can tell a hung or crashed server apart from one that's just still loading a map. The status shows up next to your container:
+
+```bash
+docker ps
+```
+
+Or you can inspect it directly:
+
+```bash
+docker inspect --format='{{.State.Health.Status}}' hlds
+```
+
+> [!NOTE]  
+> The health check queries port `27015` by default. If you've changed the server's port with `+port`, set a matching `PORT` environment variable (e.g. `-e PORT=27016`) so it checks the right one.
+
+### Keeping Game Files Updated 🔄
+
+Game files are only installed at build time, so restarting a container won't pick up a new Valve patch on its own. Set the `AUTO_UPDATE` environment variable to have the container re-check Steam for updates every time it starts:
+
+```bash
+docker run -d -ti \
+  --name hlds \
+  -e AUTO_UPDATE=true \
+  -v "$(pwd)/config:/temp/config" \
+  -v "$(pwd)/mods:/temp/mods" \
+  -p 27015:27015/udp \
+  -p 27015:27015 \
+  -p 26900:26900/udp \
+  jives/hlds:valve \
+  "+log on +rcon_password changeme +maxplayers 12 +map crossfire"
+```
+
+> [!NOTE]  
+> This adds a SteamCMD check to every container start (slower boot, and requires outbound network access), and means the same running container can end up on different game binaries over time. Published images already get refreshed weekly (in addition to whenever a manual release ships), so most people don't need this - `AUTO_UPDATE` is for when even a week of staleness isn't acceptable, or you're building your own image and want it to self-update rather than rebuilding it yourself.
+
 ## Advanced Setup ⚙️
 
 To customize the server client further, please check out the following advanced setup guides.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ You can run the following in your terminal to get started as quickly as possible
 ```bash
 docker run -d -ti \
   --name hlds \
+  --restart unless-stopped \
   -v "$(pwd)/config:/temp/config" \
   -v "$(pwd)/mods:/temp/mods" \
   -p 27015:27015/udp \
@@ -81,6 +82,7 @@ Game files are only installed at build time, so restarting a container won't pic
 ```bash
 docker run -d -ti \
   --name hlds \
+  --restart unless-stopped \
   -e AUTO_UPDATE=true \
   -v "$(pwd)/config:/temp/config" \
   -v "$(pwd)/mods:/temp/mods" \

--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ docker run -d -ti \
 > [!NOTE]  
 > This adds a SteamCMD check to every container start (slower boot, and requires outbound network access), and means the same running container can end up on different game binaries over time. Published images already get refreshed weekly (in addition to whenever a manual release ships), so most people don't need this - `AUTO_UPDATE` is for when even a week of staleness isn't acceptable, or you're building your own image and want it to self-update rather than rebuilding it yourself.
 
+> [!TIP]  
+> The default `HEALTHCHECK` timing (see Health Checks above) assumes `hlds_run` starts promptly - a slow `AUTO_UPDATE` pass on a throttled connection can outrun that budget and get the container flagged unhealthy before the server has even launched. If you hit this, override the timing at runtime rather than waiting on it: `docker run --health-start-period=180s ...`.
+
 ## Advanced Setup ⚙️
 
 To customize the server client further, please check out the following advanced setup guides.

--- a/README.md
+++ b/README.md
@@ -92,10 +92,7 @@ docker run -d -ti \
 ```
 
 > [!NOTE]  
-> This adds a SteamCMD check to every container start (slower boot, and requires outbound network access), and means the same running container can end up on different game binaries over time. Published images already get refreshed weekly (in addition to whenever a manual release ships), so most people don't need this - `AUTO_UPDATE` is for when even a week of staleness isn't acceptable, or you're building your own image and want it to self-update rather than rebuilding it yourself.
-
-> [!TIP]  
-> The default `HEALTHCHECK` timing (see Health Checks above) assumes `hlds_run` starts promptly - a slow `AUTO_UPDATE` pass on a throttled connection can outrun that budget and get the container flagged unhealthy before the server has even launched. If you hit this, override the timing at runtime rather than waiting on it: `docker run --health-start-period=180s ...`.
+> This adds a SteamCMD check to every container start (slower boot, and requires outbound network access), and means the same running container can end up on different game binaries over time. Published images already get refreshed weekly (in addition to whenever a manual release ships), so most people don't need this - `AUTO_UPDATE` is for when even a week of staleness isn't acceptable, or you're building your own image and want it to self-update rather than rebuilding it yourself. On a slow connection it can also outrun the default `HEALTHCHECK` start-period budget, flagging the container unhealthy before the server has even launched - override the timing at runtime if you hit this: `docker run --health-start-period=180s ...`.
 
 ## Advanced Setup ⚙️
 

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -77,14 +77,20 @@ RUN mkdir -p $HOME/.steam \
 
 WORKDIR /opt/steam/hlds
 
-# Copies the entrypoint script to the container and sets the necessary permissions.
+# Copies the entrypoint and healthcheck scripts to the container and sets the necessary permissions.
 COPY --chown=steam:steam ./entrypoint.sh ./entrypoint.sh
+COPY --chown=steam:steam ./healthcheck.sh ./healthcheck.sh
 COPY --chown=steam:steam config $GAME
 COPY --chown=steam:steam mods .
 
-# Sets the entrypoint script as executable.
-RUN chmod +x ./entrypoint.sh
+# Sets the entrypoint and healthcheck scripts as executable.
+RUN chmod +x ./entrypoint.sh ./healthcheck.sh
 
+# Polls the server with a real A2S_INFO query so Docker (and orchestrators
+# reading the container health status) can tell a hung/crashed hlds_run apart
+# from one that's just still loading the map.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+    CMD ["./healthcheck.sh"]
 
 # tini is PID 1 so docker stop's SIGTERM is actually handled - hlds_run
 # doesn't trap it, and untrapped signals are ignored by default for PID 1.

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -86,9 +86,7 @@ COPY --chown=steam:steam mods .
 # Sets the entrypoint and healthcheck scripts as executable.
 RUN chmod +x ./entrypoint.sh ./healthcheck.sh
 
-# Polls the server with a real A2S_INFO query so Docker (and orchestrators
-# reading the container health status) can tell a hung/crashed hlds_run apart
-# from one that's just still loading the map.
+# Polls with a real A2S_INFO query so a hung/crashed server is distinguishable from a healthy one.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
     CMD ["./healthcheck.sh"]
 

--- a/container/docker-compose.yml
+++ b/container/docker-compose.yml
@@ -7,6 +7,7 @@ services:
         - FLAG=${FLAG}
         - VERSION=${VERSION}
         - IMAGE=${IMAGE}
+    restart: unless-stopped
     volumes:
       - "./config:/temp/config"
       - "./mods:/temp/mods"

--- a/container/docker-compose.yml
+++ b/container/docker-compose.yml
@@ -19,4 +19,6 @@ services:
       - FLAG=${FLAG}
       - VERSION=${VERSION}
       - IMAGE=${IMAGE}
+      # 📣 Uncomment to have the container re-check Steam for game file updates on every start.
+      # - AUTO_UPDATE=true
     command: +maxplayers 12 +log on +rcon_password "changeme" +map crossfire

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -5,12 +5,12 @@ VERSION=${VERSION:-custom}
 IMAGE=${IMAGE:-custom}
 
 if echo "$@" | grep -qv "+map"; then
-  echo -e "\e[33mWarning: No +map specified in the command. Server will start but may not be joinable.\e[0m"
+  printf '\033[33mWarning: No +map specified in the command. Server will start but may not be joinable.\033[0m\n'
 fi
 
 # Every doc/compose example uses "changeme" - warn if it was never changed.
 if echo "$@" | grep -Eqi '\+rcon_password[[:space:]]+"?changeme"?([[:space:]]|$)'; then
-  echo -e "\e[33mWarning: rcon_password is still set to the example default 'changeme'. Anyone can use RCON to administer your server - change it to something private.\e[0m"
+  printf '\033[33mWarning: rcon_password is still set to the example default '"'"'changeme'"'"'. Anyone can use RCON to administer your server - change it to something private.\033[0m\n'
 fi
 
 # Opt-in game file refresh - runs before the mods/config sync so user files still win.
@@ -77,7 +77,7 @@ echo "
 ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
 "
 
-echo "\e[32mStarting Half-Life Dedicated Server...\e[0m"
+printf '\033[32mStarting Half-Life Dedicated Server...\033[0m\n'
 
 # Start the server with the specified game and any additional arguments.
 # sv_tags is before $@ so a user-supplied +sv_tags overrides it (last wins).

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -8,17 +8,12 @@ if echo "$@" | grep -qv "+map"; then
   echo -e "\e[33mWarning: No +map specified in the command. Server will start but may not be joinable.\e[0m"
 fi
 
-# Every example in the docs/compose files uses "changeme" as a placeholder -
-# warn if it looks like it was never actually changed, since RCON grants
-# full remote admin control over the server.
+# Every doc/compose example uses "changeme" - warn if it was never changed.
 if echo "$@" | grep -Eqi '\+rcon_password[[:space:]]+"?changeme"?([[:space:]]|$)'; then
   echo -e "\e[33mWarning: rcon_password is still set to the example default 'changeme'. Anyone can use RCON to administer your server - change it to something private.\e[0m"
 fi
 
-# Opt-in: re-run SteamCMD against the persisted install dir before launch so
-# a container restart can pick up Valve patches without an image rebuild.
-# Runs before the mods/config sync below so user-provided files still win if
-# an update restores a default (e.g. motd.txt, mapcycle.txt).
+# Opt-in game file refresh - runs before the mods/config sync so user files still win.
 if [ "$AUTO_UPDATE" = "1" ] || [ "$AUTO_UPDATE" = "true" ]; then
   echo "AUTO_UPDATE is enabled, checking Steam for updated $GAME game files..."
   /opt/steam/steamcmd.sh \

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -8,6 +8,29 @@ if echo "$@" | grep -qv "+map"; then
   echo -e "\e[33mWarning: No +map specified in the command. Server will start but may not be joinable.\e[0m"
 fi
 
+# Every example in the docs/compose files uses "changeme" as a placeholder -
+# warn if it looks like it was never actually changed, since RCON grants
+# full remote admin control over the server.
+if echo "$@" | grep -Eqi '\+rcon_password[[:space:]]+"?changeme"?([[:space:]]|$)'; then
+  echo -e "\e[33mWarning: rcon_password is still set to the example default 'changeme'. Anyone can use RCON to administer your server - change it to something private.\e[0m"
+fi
+
+# Opt-in: re-run SteamCMD against the persisted install dir before launch so
+# a container restart can pick up Valve patches without an image rebuild.
+# Runs before the mods/config sync below so user-provided files still win if
+# an update restores a default (e.g. motd.txt, mapcycle.txt).
+if [ "$AUTO_UPDATE" = "1" ] || [ "$AUTO_UPDATE" = "true" ]; then
+  echo "AUTO_UPDATE is enabled, checking Steam for updated $GAME game files..."
+  /opt/steam/steamcmd.sh \
+    +@ShutdownOnFailedCommand 0 \
+    +@NoPromptForPassword 1 \
+    +force_install_dir /opt/steam/hlds \
+    +login anonymous \
+    +app_set_config 90 mod "$GAME" \
+    +app_update 90 $FLAG validate \
+    +quit
+fi
+
 # Push mods and config files from their temp directories to the server directories.
 
 if [ -d /temp/mods ]

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -9,8 +9,10 @@ if echo "$@" | grep -qv "+map"; then
 fi
 
 # Every doc/compose example uses "changeme" - warn if it was never changed.
+# Also drops a sentinel file: CI checks that instead of docker logs, which can lag under load.
 if echo "$@" | grep -Eqi '\+rcon_password[[:space:]]+"?changeme"?([[:space:]]|$)'; then
   printf '\033[33mWarning: rcon_password is still set to the example default '"'"'changeme'"'"'. Anyone can use RCON to administer your server - change it to something private.\033[0m\n'
+  touch /tmp/.rcon-default-password-warning-shown
 fi
 
 # Opt-in game file refresh - runs before the mods/config sync so user files still win.
@@ -24,6 +26,7 @@ if [ "$AUTO_UPDATE" = "1" ] || [ "$AUTO_UPDATE" = "true" ]; then
     +app_set_config 90 mod "$GAME" \
     +app_update 90 $FLAG validate \
     +quit
+  touch /tmp/.auto-update-ran
 fi
 
 # Push mods and config files from their temp directories to the server directories.

--- a/container/healthcheck.sh
+++ b/container/healthcheck.sh
@@ -1,17 +1,11 @@
 #!/usr/bin/env bash
 
-# Confirms the server answers a raw A2S_INFO query over UDP, the same query
-# Steam's server browser and check_a2s_info.py use to determine liveness.
-# Uses bash's built-in /dev/udp so no extra dependencies (netcat, python) are
-# needed in the runtime image.
+# Polls the server with a raw A2S_INFO UDP query via bash's /dev/udp, avoiding extra deps.
 
 PORT="${PORT:-27015}"
 [[ "$PORT" =~ ^[0-9]+$ ]] || PORT=27015
 
-# A single read of the datagram is required: UDP sockets hand back one
-# datagram per read(), so asking for it in small chunks (e.g. `dd bs=1`)
-# discards the rest of the packet after the first chunk and hangs waiting
-# for a second datagram that will never arrive.
+# One read only - UDP hands back a full datagram per read(), so small reads lose the rest and hang.
 RESPONSE_HEX=$(timeout 3 bash -c "
   exec 3<>/dev/udp/127.0.0.1/$PORT || exit 1
   printf '\xff\xff\xff\xffTSource Engine Query\x00' >&3

--- a/container/healthcheck.sh
+++ b/container/healthcheck.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Confirms the server answers a raw A2S_INFO query over UDP, the same query
+# Steam's server browser and check_a2s_info.py use to determine liveness.
+# Uses bash's built-in /dev/udp so no extra dependencies (netcat, python) are
+# needed in the runtime image.
+
+PORT="${PORT:-27015}"
+[[ "$PORT" =~ ^[0-9]+$ ]] || PORT=27015
+
+# A single read of the datagram is required: UDP sockets hand back one
+# datagram per read(), so asking for it in small chunks (e.g. `dd bs=1`)
+# discards the rest of the packet after the first chunk and hangs waiting
+# for a second datagram that will never arrive.
+RESPONSE_HEX=$(timeout 3 bash -c "
+  exec 3<>/dev/udp/127.0.0.1/$PORT || exit 1
+  printf '\xff\xff\xff\xffTSource Engine Query\x00' >&3
+  dd bs=4096 count=1 <&3 2>/dev/null | head -c 4 | od -An -tx1 | tr -d ' \n'
+")
+
+[ "$RESPONSE_HEX" = "ffffffff" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
       - "26900:2690/udp"
     environment:
       - GAME=${GAME}
+      # 📣 Uncomment to have the container re-check Steam for game file updates on every start.
+      # - AUTO_UPDATE=true
     # 📣 Modify your server startup commands here, you can add more flags as needed (see: https://developer.valvesoftware.com/wiki/Half-Life_Dedicated_Server),
     # 📣 Remember: Stating map is based on the game, and will likely be different between images.
     # 📣 You should also modify the rcon_password value so you can use server admin commands.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     # 🔧 jives/hlds:czero-legacy (Counter-Strike: Condition Zero) (Pre 25th Anniversary Edition)
     # 🔧 jives/hlds:tfc-legacy (Team Fortress Classic) (Pre 25th Anniversary Edition)
     image: jives/hlds:valve
+    restart: unless-stopped
     # 📣 Learn more about these volumes in the advanced setup guides: https://github.com/JamesIves/hlds-docker?tab=readme-ov-file#advanced-setup-%EF%B8%8F
     volumes:
       - "./config:/temp/config"

--- a/docs/index.html
+++ b/docs/index.html
@@ -693,13 +693,6 @@
                 >
                   Build a Custom Image
                 </a>
-                <a
-                  href="https://github.com/JamesIves/hlds-docker/blob/beta/README.md"
-                  target="_blank"
-                  class="action-button"
-                >
-                  Keeping Game Files Updated
-                </a>
               </div>
             </fieldset>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -693,6 +693,13 @@
                 >
                   Build a Custom Image
                 </a>
+                <a
+                  href="https://github.com/JamesIves/hlds-docker/blob/beta/README.md"
+                  target="_blank"
+                  class="action-button"
+                >
+                  Keeping Game Files Updated
+                </a>
               </div>
             </fieldset>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -659,6 +659,13 @@
                   Enable Cheats (sv_cheats 1)
                 </label>
               </div>
+
+              <div class="checkbox-row">
+                <label>
+                  <input type="checkbox" id="autoupdate" />
+                  Auto-Update Game Files (AUTO_UPDATE)
+                </label>
+              </div>
             </fieldset>
 
             <fieldset>
@@ -959,6 +966,7 @@
         password = "",
         lanmode = false,
         cheats = false,
+        autoupdate = false,
       }) {
         const resolvedMap = map || (mapData[game] && mapData[game][0]) || "";
         let players = parseInt(maxplayers, 10);
@@ -971,8 +979,13 @@
   -v "$(pwd)/config:/temp/config" \\
   -v "$(pwd)/mods:/temp/mods" \\
   -p 27015:27015/udp \\
-  -p 27015:27015 \\
-  jives/hlds:${game} \\
+  -p 27015:27015 \\`;
+
+        if (autoupdate) {
+          command += `\n  -e AUTO_UPDATE=true \\`;
+        }
+
+        command += `\n  jives/hlds:${game} \\
   +log on`;
 
         if (rcon) {
@@ -1009,6 +1022,7 @@
         const password = document.getElementById("password").value;
         const lanmode = document.getElementById("lanmode").checked;
         const cheats = document.getElementById("cheats").checked;
+        const autoupdate = document.getElementById("autoupdate").checked;
 
         // Ensure maxplayers has a minimum value of 1 and keep the input field in sync
         let maxplayers = parseInt(maxplayersInput.value, 10);
@@ -1026,6 +1040,7 @@
           password,
           lanmode,
           cheats,
+          autoupdate,
         });
       }
 
@@ -1078,6 +1093,11 @@
                   type: "boolean",
                   description: "Enable cheats (sv_cheats 1).",
                 },
+                autoupdate: {
+                  type: "boolean",
+                  description:
+                    "Re-check Steam for updated game files on every container start (AUTO_UPDATE).",
+                },
               },
               required: ["game"],
             },
@@ -1115,6 +1135,9 @@
         .addEventListener("change", updateCommand);
       document
         .getElementById("cheats")
+        .addEventListener("change", updateCommand);
+      document
+        .getElementById("autoupdate")
         .addEventListener("change", updateCommand);
 
       // Initial setup


### PR DESCRIPTION
### Description 📝

Three related additions, plus a small security nudge:

- **`HEALTHCHECK`**: the image now ships a Docker `HEALTHCHECK` (`container/healthcheck.sh`) that polls the server every 30s with a real `A2S_INFO` query over UDP - the same query Steam's server browser uses - so `docker ps` and orchestrators can tell a hung or crashed server apart from a healthy one.
- **`AUTO_UPDATE`** (opt-in, off by default): re-runs SteamCMD against the persisted install dir before launch, so a container restart can pick up a Valve patch without an image rebuild. Runs before the mods/config sync so user files still win.
- **Weekly evergreen releases**: `publish.yml` now also runs on a schedule (`0 6 * * 0`) in addition to manual dispatch. The scheduled path rebuilds `main`'s already-released code against the current Steam depot and cuts a patch release - it never touches the `beta -> main` promotion, so a work-in-progress commit on `beta` can't get shipped by the timer. It's gated on `check_steam_updates.py`, which skips the entire rebuild/publish cycle if Steam's `app_info` hasn't changed since the last release, so a quiet week stops after one lightweight metadata query instead of publishing ~12 no-op version tags to each registry.
- Also warns at startup if `rcon_password` is left at the `changeme` placeholder every doc/compose example uses, mirroring the existing `+map` warning.
